### PR TITLE
Start developing against AssertJ 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.assertj</groupId>
     <artifactId>assertj-parent</artifactId>
-    <version>3.27.3</version>
+    <version>4.0.0-M1</version>
   </parent>
 
   <artifactId>assertj-eclipse-collections</artifactId>
@@ -38,8 +38,8 @@
   </scm>
 
   <properties>
-    <assertj.version>3.27.3</assertj.version>
-    <java.version>11</java.version>
+    <assertj.version>4.0.0-M1</assertj.version>
+    <java.version>17</java.version>
     <eclipse-collections.version>13.0.0</eclipse-collections.version>
     <!-- Dependency versions overriding -->
     <junit-jupiter.version>5.12.1</junit-jupiter.version>
@@ -85,6 +85,8 @@
               <link>https://javadoc.io/static/org.assertj/assertj-core/${assertj.version}/</link>
               <link>https://javadoc.io/static/org.eclipse.collections/eclipse-collections-api/${eclipse-collections.version}/</link>
             </links>
+            <!-- https://bugs.openjdk.org/browse/JDK-8274639 -->
+            <additionalOptions>--allow-script-in-comments --link-modularity-mismatch=info</additionalOptions>
           </configuration>
         </plugin>
       </plugins>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+/**
+ * Main AssertJ Eclipse Collections Module
+ */
+module org.assertj.eclipse.collections {
+  exports org.assertj.eclipse.collections.api;
+  exports org.assertj.eclipse.collections.api.multimap;
+  exports org.assertj.eclipse.collections.error;
+
+  requires org.assertj.core;
+  requires org.eclipse.collections.api;
+  requires org.eclipse.collections.impl;
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/SoftAssertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/SoftAssertions.java
@@ -14,7 +14,6 @@ package org.assertj.eclipse.collections.api;
 
 import org.assertj.core.api.AbstractSoftAssertions;
 import org.assertj.core.api.SoftAssertionsProvider;
-import org.opentest4j.MultipleFailuresError;
 
 import java.util.function.Consumer;
 
@@ -35,8 +34,8 @@ public class SoftAssertions extends AbstractSoftAssertions implements EclipseCol
    *
    * @param softly the Consumer containing the code that will make the soft assertions.
    *               Takes one parameter (the SoftAssertions instance used to make the assertions).
-   * @throws MultipleFailuresError if possible or SoftAssertionError if any proxied assertion objects threw an {@link
-   *                               AssertionError}
+   * @throws org.opentest4j.MultipleFailuresError MultipleFailuresError if possible or SoftAssertionError if any proxied
+   *                                              assertion objects threw an {@link AssertionError}
    */
   public static void assertSoftly(Consumer<SoftAssertions> softly) {
     SoftAssertionsProvider.assertSoftly(SoftAssertions.class, softly);

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2025-2025 the original author or authors.
+ */
+
+/**
+ * Test module for AssertJ Eclipse Collections
+ */
+open module org.assertj.eclipse.collections.test {
+  exports org.assertj.eclipse.collections.test.api.multimap;
+
+  requires org.assertj.eclipse.collections;
+  requires org.assertj.core;
+  requires org.eclipse.collections.api;
+  requires org.eclipse.collections.impl;
+  requires org.junit.jupiter.api;
+  requires org.junit.jupiter.params;
+}

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsEntry_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsEntry_Test.java
@@ -10,16 +10,14 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.eclipse.collections.impl.tuple.Tuples.pair;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
-import org.eclipse.collections.api.tuple.Pair;
-import org.eclipse.collections.impl.factory.Multimaps;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -27,13 +25,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 class MultimapAssert_ContainsEntry_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void passes(Multimap<String, String> actual) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).containsEntry("ENT", "Reed"));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsEmpty(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).containsEntry("ENT", "Reed"))
@@ -50,7 +48,7 @@ class MultimapAssert_ContainsEntry_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void failsMissingEntry(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).containsEntry("VOY", "Kes"))
@@ -60,7 +58,7 @@ class MultimapAssert_ContainsEntry_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void softAssertionPasses(Multimap<String, String> actual) {
     SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).containsEntry("ENT", "Reed"));
   }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsKeys_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsKeys_Test.java
@@ -10,55 +10,56 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_ContainsValues_Test {
+class MultimapAssert_ContainsKeys_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void passes(Multimap<String, String> actual) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"));
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).containsKeys("TOS", "TNG", "DS9"));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsEmpty(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"))
+      .isThrownBy(() -> new MultimapAssert<>(actual).containsKeys("TOS", "TNG", "DS9"))
       .withMessageContaining("Expecting actual")
       .withMessageContaining("{}")
-      .withMessageContaining("to contain values");
+      .withMessageContaining("to contain keys");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
-  void failsMissingValue(Multimap<String, String> actual) {
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  void failsMissingKey(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).containsValues("Kes"))
+      .isThrownBy(() -> new MultimapAssert<>(actual).containsKeys("DIS"))
       .withMessageContaining("Expecting actual")
-      .withMessageContaining("to contain value")
-      .withMessageContaining("Kes");
+      .withMessageContaining("to contain key")
+      .withMessageContaining("DIS");
   }
 
   @Test
   void failsNullMultimap() {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"))
+      .isThrownBy(() -> new MultimapAssert<>(null).containsKeys("TOS", "TNG", "DS9"))
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void softAssertionPasses(Multimap<String, String> actual) {
-    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"));
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).containsKeys("TOS", "TNG", "DS9"));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsOnly_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsOnly_Test.java
@@ -10,7 +10,7 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -19,6 +19,7 @@ import static org.eclipse.collections.impl.tuple.Tuples.pair;
 import java.util.Map;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class MultimapAssert_ContainsOnly_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void passesWithPairs(Multimap<String, String> actual) {
     Pair<String, String>[] exactMatchPairs = new Pair[]{
       pair("TNG", "Enterprise"),
@@ -40,7 +41,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void passesWithEntries(Multimap<String, String> actual) {
     Map.Entry<String, String>[] exactMatchEntries = new Map.Entry[]{
       pair("TNG", "Enterprise").toEntry(),
@@ -52,7 +53,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void failsWhenAdditionalKeysOrValuesExistWithPair(Multimap<String, String> actual) {
     Pair<String, String>[] partialMatchMissingPairs = new Pair[]{
       pair("TNG", "Enterprise"),
@@ -66,7 +67,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void failsWhenAdditionalKeysOrValuesExistWithEntry(Multimap<String, String> actual) {
     Map.Entry<String, String>[] partialMatchMissingEntries = new Map.Entry[]{
       pair("TNG", "Enterprise").toEntry(),
@@ -80,7 +81,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void failsWhenEntryIsMissingWithPair(Multimap<String, String> actual) {
     Pair<String, String>[] partialMatchExtraPairs = new Pair[]{
       pair("TOS", "Enterprise"),
@@ -96,7 +97,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void failsWhenEntryIsMissingWithEntry(Multimap<String, String> actual) {
     Map.Entry<String, String>[] partialMatchExtraEntries = new Map.Entry[]{
       pair("TOS", "Enterprise").toEntry(),
@@ -112,7 +113,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsForEmptyMultimapWithPair(Multimap<String, String> actual) {
     Pair<String, String>[] exactMatchPairs = new Pair[]{
       pair("TNG", "Enterprise"),
@@ -125,7 +126,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsForEmptyMultimapWithEntry(Multimap<String, String> actual) {
     Map.Entry<String, String>[] exactMatchEntries = new Map.Entry[]{
       pair("TNG", "Enterprise").toEntry(),
@@ -160,7 +161,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void softAssertionPassesWithPairs(Multimap<String, String> actual) {
     Pair<String, String>[] exactMatchPairs = new Pair[]{
       pair("TNG", "Enterprise"),
@@ -172,7 +173,7 @@ class MultimapAssert_ContainsOnly_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#shipMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#shipMultimaps")
   void softAssertionPassesWithEntries(Multimap<String, String> actual) {
     Map.Entry<String, String>[] exactMatchEntries = new Map.Entry[]{
       pair("TNG", "Enterprise").toEntry(),

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsValues_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_ContainsValues_Test.java
@@ -10,55 +10,56 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_ContainsKeys_Test {
+class MultimapAssert_ContainsValues_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void passes(Multimap<String, String> actual) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).containsKeys("TOS", "TNG", "DS9"));
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsEmpty(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).containsKeys("TOS", "TNG", "DS9"))
+      .isThrownBy(() -> new MultimapAssert<>(actual).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"))
       .withMessageContaining("Expecting actual")
       .withMessageContaining("{}")
-      .withMessageContaining("to contain keys");
+      .withMessageContaining("to contain values");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
-  void failsMissingKey(Multimap<String, String> actual) {
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  void failsMissingValue(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).containsKeys("DIS"))
+      .isThrownBy(() -> new MultimapAssert<>(actual).containsValues("Kes"))
       .withMessageContaining("Expecting actual")
-      .withMessageContaining("to contain key")
-      .withMessageContaining("DIS");
+      .withMessageContaining("to contain value")
+      .withMessageContaining("Kes");
   }
 
   @Test
   void failsNullMultimap() {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).containsKeys("TOS", "TNG", "DS9"))
+      .isThrownBy(() -> new MultimapAssert<>(null).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"))
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void softAssertionPasses(Multimap<String, String> actual) {
-    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).containsKeys("TOS", "TNG", "DS9"));
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).containsValues("Kirk", "Picard", "Sisko", "Janeway", "Archer"));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_Contains_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_Contains_Test.java
@@ -10,7 +10,7 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasDistinctSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasDistinctSizeGreaterThan_Test.java
@@ -10,14 +10,14 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
-import org.eclipse.collections.impl.factory.Multimaps;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,13 +25,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 class MultimapAssert_HasDistinctSizeGreaterThan_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#distinctSizeLowerBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#distinctSizeLowerBoundaryTestData")
   void passesGreaterThan(Multimap<String, String> actual, int lowerBoundary) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasDistinctSizeGreaterThan(lowerBoundary));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#distinctSizeUpperBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#distinctSizeUpperBoundaryTestData")
   void failsLesser(Multimap<String, String> actual, int upperBoundary) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasDistinctSizeGreaterThan(upperBoundary))
@@ -40,7 +40,7 @@ class MultimapAssert_HasDistinctSizeGreaterThan_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#distinctSizeEqualsTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#distinctSizeEqualsTestData")
   void failsEquals(Multimap<String, String> actual, int equalsBoundary) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasDistinctSizeGreaterThan(equalsBoundary))
@@ -57,7 +57,7 @@ class MultimapAssert_HasDistinctSizeGreaterThan_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsEmptyMultimap(Multimap<String, String> actual) {
     int lowerBoundary = 2; // Using the same value as in distinctSizeLowerBoundaryTestData
     assertThatExceptionOfType(AssertionError.class)
@@ -66,7 +66,7 @@ class MultimapAssert_HasDistinctSizeGreaterThan_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#distinctSizeLowerBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#distinctSizeLowerBoundaryTestData")
   void softAssertionPasses(Multimap<String, String> actual, int lowerBoundary) {
     SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasDistinctSizeGreaterThan(lowerBoundary));
   }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasDistinctSize_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasDistinctSize_Test.java
@@ -10,44 +10,45 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_IsEmpty_Test {
+class MultimapAssert_HasDistinctSize_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
-  void passes(Multimap<String, String> actual) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).isEmpty());
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#distinctSizeEqualsTestData")
+  void passes(Multimap<String, String> actual, int expectedSize) {
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasDistinctSize(expectedSize));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
-  void failsNotEmpty(Multimap<String, String> actual) {
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimapsWithExpectedDistinctSize")
+  void failsEmpty(Multimap<String, String> actual, int expectedSize) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).isEmpty())
-      .withMessageContaining("Expecting empty but was: " + actual.toString());
+      .isThrownBy(() -> new MultimapAssert<>(actual).hasDistinctSize(expectedSize))
+      .withMessageContaining(String.format("Expected distinct size: %s but was: 0", expectedSize));
   }
 
   @Test
   void failsNullMultimap() {
+    int expectedSize = 5; // Using the same value as in distinctSizeEqualsTestData
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).isEmpty())
+      .isThrownBy(() -> new MultimapAssert<>(null).hasDistinctSize(expectedSize))
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
-  void softAssertionPasses(Multimap<String, String> actual) {
-    assertThatNoException().isThrownBy(() ->
-      SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).isEmpty()));
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#distinctSizeEqualsTestData")
+  void softAssertionPasses(Multimap<String, String> actual, int expectedSize) {
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasDistinctSize(expectedSize));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasKeySatisfying_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasKeySatisfying_Test.java
@@ -10,13 +10,14 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.core.api.Condition;
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,13 +29,13 @@ class MultimapAssert_HasKeySatisfying_Test {
   private static final Condition<Object> FAILING_CONDITION = new Condition<>("DIS"::equals, "key equals DIS");
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void passesKeySatisfying(Multimap<String, String> actual) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasKeySatisfying(PASSING_CONDITION));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void failsKeyNotSatisfying(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasKeySatisfying(FAILING_CONDITION))
@@ -49,7 +50,7 @@ class MultimapAssert_HasKeySatisfying_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void softAssertionPasses(Multimap<String, String> actual) {
     SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasKeySatisfying(PASSING_CONDITION));
   }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeBetween_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeBetween_Test.java
@@ -10,12 +10,13 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,25 +25,25 @@ import org.junit.jupiter.params.provider.MethodSource;
 class MultimapAssert_HasSizeBetween_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeBetweenTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeBetweenTestData")
   void passesSizeBetween(Multimap<String, String> actual, int lowerBoundary, int upperBoundary) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeBetween(lowerBoundary, upperBoundary));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeBetweenInclusiveUpperTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeBetweenInclusiveUpperTestData")
   void passesSizeBetweenInclusiveUpper(Multimap<String, String> actual, int lowerBoundary, int upperBoundary) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeBetween(lowerBoundary, upperBoundary));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeBetweenInclusiveLowerTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeBetweenInclusiveLowerTestData")
   void passesSizeBetweenInclusiveLower(Multimap<String, String> actual, int lowerBoundary, int upperBoundary) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeBetween(lowerBoundary, upperBoundary));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeBelowLowerBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeBelowLowerBoundaryTestData")
   void failsSizeFallsBelowLowerBoundary(Multimap<String, String> actual, int lowerBoundary, int upperBoundary) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeBetween(lowerBoundary, upperBoundary))
@@ -50,7 +51,7 @@ class MultimapAssert_HasSizeBetween_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeAboveUpperBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeAboveUpperBoundaryTestData")
   void failsSizeFallsAboveUpperBoundary(Multimap<String, String> actual, int lowerBoundary, int upperBoundary) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeBetween(lowerBoundary, upperBoundary))
@@ -65,7 +66,7 @@ class MultimapAssert_HasSizeBetween_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsEmptyMultimap(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeBetween(25, 50))
@@ -73,7 +74,7 @@ class MultimapAssert_HasSizeBetween_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeBetweenTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeBetweenTestData")
   void softAssertionPasses(Multimap<String, String> actual, int lowerBoundary, int upperBoundary) {
     SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSizeBetween(lowerBoundary, upperBoundary));
   }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeGreaterThan_Test.java
@@ -10,12 +10,13 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,13 +25,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 class MultimapAssert_HasSizeGreaterThan_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
   void passesGreaterThan(Multimap<String, String> actual, int lowerBoundary) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeGreaterThan(lowerBoundary));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
   void failsLesser(Multimap<String, String> actual, int upperBoundary) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeGreaterThan(upperBoundary))
@@ -39,7 +40,7 @@ class MultimapAssert_HasSizeGreaterThan_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeEqualsTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeEqualsTestData")
   void failsEquals(Multimap<String, String> actual, int equalsBoundary) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeGreaterThan(equalsBoundary))
@@ -55,7 +56,7 @@ class MultimapAssert_HasSizeGreaterThan_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void failsEmptyMultimap(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeGreaterThan(5))
@@ -63,7 +64,7 @@ class MultimapAssert_HasSizeGreaterThan_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
   void softAssertionPasses(Multimap<String, String> actual, int lowerBoundary) {
     SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSizeGreaterThan(lowerBoundary));
   }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeLessThanOrEqualTo_Test.java
@@ -10,53 +10,51 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_HasSizeLessThan_Test {
+class MultimapAssert_HasSizeLessThanOrEqualTo_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
   void passesLessThan(Multimap<String, String> actual, int upperBoundary) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThan(upperBoundary));
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThanOrEqualTo(upperBoundary));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeEqualsTestData")
+  void passesEqual(Multimap<String, String> actual, int equalsBoundary) {
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThanOrEqualTo(equalsBoundary));
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
   void failsGreater(Multimap<String, String> actual, int lowerBoundary) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThan(lowerBoundary))
+      .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThanOrEqualTo(lowerBoundary))
       .withMessageContaining("Expecting size of")
-      .withMessageContaining(String.format("to be less than %s but was %s", lowerBoundary, actual.size()));
-  }
-
-  @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeEqualsTestData")
-  void failsEquals(Multimap<String, String> actual, int equalsBoundary) {
-    assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThan(equalsBoundary))
-      .withMessageContaining("Expecting size of")
-      .withMessageContaining(String.format("to be less than %s but was %s", equalsBoundary, actual.size()));
+      .withMessageContaining(String.format("to be less than or equal to %s but was %s", lowerBoundary, actual.size()));
   }
 
   @Test
   void failsNullMultimap() {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).hasSizeLessThan(50))
+      .isThrownBy(() -> new MultimapAssert<>(null).hasSizeLessThanOrEqualTo(42))
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
   void softAssertionPasses(Multimap<String, String> actual, int upperBoundary) {
-    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSizeLessThan(upperBoundary));
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSizeLessThanOrEqualTo(upperBoundary));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeLessThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSizeLessThan_Test.java
@@ -10,50 +10,54 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_HasSizeLessThanOrEqualTo_Test {
+class MultimapAssert_HasSizeLessThan_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
   void passesLessThan(Multimap<String, String> actual, int upperBoundary) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThanOrEqualTo(upperBoundary));
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThan(upperBoundary));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeEqualsTestData")
-  void passesEqual(Multimap<String, String> actual, int equalsBoundary) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThanOrEqualTo(equalsBoundary));
-  }
-
-  @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeLowerBoundaryTestData")
   void failsGreater(Multimap<String, String> actual, int lowerBoundary) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThanOrEqualTo(lowerBoundary))
+      .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThan(lowerBoundary))
       .withMessageContaining("Expecting size of")
-      .withMessageContaining(String.format("to be less than or equal to %s but was %s", lowerBoundary, actual.size()));
+      .withMessageContaining(String.format("to be less than %s but was %s", lowerBoundary, actual.size()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeEqualsTestData")
+  void failsEquals(Multimap<String, String> actual, int equalsBoundary) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new MultimapAssert<>(actual).hasSizeLessThan(equalsBoundary))
+      .withMessageContaining("Expecting size of")
+      .withMessageContaining(String.format("to be less than %s but was %s", equalsBoundary, actual.size()));
   }
 
   @Test
   void failsNullMultimap() {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).hasSizeLessThanOrEqualTo(42))
+      .isThrownBy(() -> new MultimapAssert<>(null).hasSizeLessThan(50))
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeUpperBoundaryTestData")
   void softAssertionPasses(Multimap<String, String> actual, int upperBoundary) {
-    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSizeLessThanOrEqualTo(upperBoundary));
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSizeLessThan(upperBoundary));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSize_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasSize_Test.java
@@ -10,47 +10,44 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
-import java.util.stream.Stream;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_IsNotEmpty_Test {
+class MultimapAssert_HasSize_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
-  void passesNotEmpty(Multimap<String, String> actual) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).isNotEmpty());
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeEqualsTestData")
+  void passes(Multimap<String, String> actual, int expectedSize) {
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSize(expectedSize));
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
-  void failsEmpty(Multimap<String, String> actual) {
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimapsWithExpectedSize")
+  void failsEmpty(Multimap<String, String> actual, int expectedSize) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).isNotEmpty())
-      .withMessageContaining("Expecting actual not to be empty");
+      .isThrownBy(() -> new MultimapAssert<>(actual).hasSize(expectedSize))
+      .withMessageContaining(String.format("Expected size: %s but was: 0", expectedSize));
   }
 
   @Test
   void failsNullMultimap() {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).isNotEmpty())
+      .isThrownBy(() -> new MultimapAssert<>(null).hasSize(38))
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
-  void softAssertionPasses(Multimap<String, String> actual) {
-    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).isNotEmpty());
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#sizeEqualsTestData")
+  void softAssertionPasses(Multimap<String, String> actual, int expectedSize) {
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSize(expectedSize));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_HasValueSatisfying_Test.java
@@ -10,7 +10,7 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.Condition;
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_IsEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_IsEmpty_Test.java
@@ -10,44 +10,45 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_HasDistinctSize_Test {
+class MultimapAssert_IsEmpty_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#distinctSizeEqualsTestData")
-  void passes(Multimap<String, String> actual, int expectedSize) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasDistinctSize(expectedSize));
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
+  void passes(Multimap<String, String> actual) {
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).isEmpty());
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimapsWithExpectedDistinctSize")
-  void failsEmpty(Multimap<String, String> actual, int expectedSize) {
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  void failsNotEmpty(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).hasDistinctSize(expectedSize))
-      .withMessageContaining(String.format("Expected distinct size: %s but was: 0", expectedSize));
+      .isThrownBy(() -> new MultimapAssert<>(actual).isEmpty())
+      .withMessageContaining("Expecting empty but was: " + actual.toString());
   }
 
   @Test
   void failsNullMultimap() {
-    int expectedSize = 5; // Using the same value as in distinctSizeEqualsTestData
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).hasDistinctSize(expectedSize))
+      .isThrownBy(() -> new MultimapAssert<>(null).isEmpty())
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#distinctSizeEqualsTestData")
-  void softAssertionPasses(Multimap<String, String> actual, int expectedSize) {
-    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasDistinctSize(expectedSize));
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
+  void softAssertionPasses(Multimap<String, String> actual) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).isEmpty()));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_IsNotEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_IsNotEmpty_Test.java
@@ -10,43 +10,44 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MultimapAssert_HasSize_Test {
+class MultimapAssert_IsNotEmpty_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeEqualsTestData")
-  void passes(Multimap<String, String> actual, int expectedSize) {
-    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).hasSize(expectedSize));
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  void passesNotEmpty(Multimap<String, String> actual) {
+    assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).isNotEmpty());
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimapsWithExpectedSize")
-  void failsEmpty(Multimap<String, String> actual, int expectedSize) {
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
+  void failsEmpty(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(actual).hasSize(expectedSize))
-      .withMessageContaining(String.format("Expected size: %s but was: 0", expectedSize));
+      .isThrownBy(() -> new MultimapAssert<>(actual).isNotEmpty())
+      .withMessageContaining("Expecting actual not to be empty");
   }
 
   @Test
   void failsNullMultimap() {
     assertThatExceptionOfType(AssertionError.class)
-      .isThrownBy(() -> new MultimapAssert<>(null).hasSize(38))
+      .isThrownBy(() -> new MultimapAssert<>(null).isNotEmpty())
       .withMessageContaining("Expecting actual not to be null");
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#sizeEqualsTestData")
-  void softAssertionPasses(Multimap<String, String> actual, int expectedSize) {
-    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).hasSize(expectedSize));
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  void softAssertionPasses(Multimap<String, String> actual) {
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).isNotEmpty());
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_IsNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapAssert_IsNullOrEmpty_Test.java
@@ -10,12 +10,13 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.assertj.eclipse.collections.api.multimap.MultimapAssert;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class MultimapAssert_IsNullOrEmpty_Test {
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void passesEmptyMultimap(Multimap<String, String> actual) {
     assertThatNoException().isThrownBy(() -> new MultimapAssert<>(actual).isNullOrEmpty());
   }
@@ -35,7 +36,7 @@ class MultimapAssert_IsNullOrEmpty_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#nonEmptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#nonEmptyMultimaps")
   void failsNotNullOrEmpty(Multimap<String, String> actual) {
     assertThatExceptionOfType(AssertionError.class)
       .isThrownBy(() -> new MultimapAssert<>(actual).isNullOrEmpty())
@@ -43,7 +44,7 @@ class MultimapAssert_IsNullOrEmpty_Test {
   }
 
   @ParameterizedTest
-  @MethodSource("org.assertj.eclipse.collections.api.multimap.MultimapTestData#emptyMultimaps")
+  @MethodSource("org.assertj.eclipse.collections.test.api.multimap.MultimapTestData#emptyMultimaps")
   void softAssertionPassesEmpty(Multimap<String, String> actual) {
     SoftAssertions.assertSoftly(softly -> softly.assertThat(actual).isNullOrEmpty());
   }

--- a/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapTestData.java
+++ b/src/test/java/org/assertj/eclipse/collections/test/api/multimap/MultimapTestData.java
@@ -10,7 +10,7 @@
  *
  * Copyright 2025-2025 the original author or authors.
  */
-package org.assertj.eclipse.collections.api.multimap;
+package org.assertj.eclipse.collections.test.api.multimap;
 
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.factory.Lists;


### PR DESCRIPTION
Motivation
----------

Eclipse Collections released version 13.0 which compiles against JDK 17. This allows us to baseline on AssertJ 4.x development which also targets JDK 17. This PR updates the project to support this. It also adds the JPMS module info files necessary to make the library a module.

Modifications
-------------

The largest modification is moving the tests to a dedicated package to avoid the split package problem across modules. There are now two module-info files: one for the main and one for the test. The test module is open by design so JUnit can find the tests. I updated the POM file to point to the 4.0.0-M1 version of AssertJ core. 

Result
------

Development can now proceed tracking all of the latest from AssertJ 4.x