### PR TITLE
Add AbstractRichIterableAssert scaffold and first concrete types (SetIterable and Bag)

### DIFF
--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractIterableAssert;
+import org.eclipse.collections.api.RichIterable;
+
+/**
+ * Base class for implementations of Eclipse Collections {@link RichIterable} assertions.
+ *
+ * @param <SELF>           the "self" type of this assertion class. Please read &quot;<a href="https://bit.ly/1IZIRcY"
+ *                         target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
+ *                         for more details.
+ * @param <ACTUAL>         the type of the "actual" value.
+ * @param <ELEMENT>        the type of elements of the "actual" value.
+ * @param <ELEMENT_ASSERT> used for navigational assertions to return the right assert type.
+ */
+//@format:off
+public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT>,
+  ACTUAL extends RichIterable<? extends ELEMENT>,
+  ELEMENT,
+  ELEMENT_ASSERT extends AbstractAssert<? extends ELEMENT_ASSERT, ELEMENT>>
+  extends AbstractIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT> {
+//@format:on
+
+  protected AbstractRichIterableAssert(ACTUAL actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  /**
+   * Verifies that the number of values in the actual RichIterable is equal to the given one.
+   * <p>
+   * Example:
+   * <pre>{@code
+   * // assertions will pass
+   * assertThat(Sets.immutable.of("TNG", "DS9")).hasSize(2);
+   * assertThat(Bags.immutable.of(1, 2, 3)).hasSize(3);
+   *
+   * // assertions will fail
+   * assertThat(Sets.immutable.empty()).hasSize(1);
+   * assertThat(Bags.immutable.of(1, 2, 3)).hasSize(2);
+   * }</pre>
+   *
+   * @param expected the expected number of values in the actual collection.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the number of values of the actual collection is not equal to the given one.
+   */
+  @Override
+  public SELF hasSize(int expected) {
+    isNotNull();
+
+    int actualSize = actual.size();
+    if (actualSize == expected) {
+      return myself;
+    }
+
+    throw assertionError(shouldHaveSize(actual, actualSize, expected));
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -16,6 +16,11 @@
 package org.assertj.eclipse.collections.api;
 
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
+import static org.assertj.core.util.Preconditions.checkArgument;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIterableAssert;
@@ -41,6 +46,36 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
 
   protected AbstractRichIterableAssert(ACTUAL actual, Class<?> selfType) {
     super(actual, selfType);
+  }
+
+  @Override
+  public <T> SELF filteredOn(Function<? super ELEMENT, T> function, T expectedValue) {
+    checkArgument(function != null, "The filter function should not be null");
+    return internalFilteredOn(element -> Objects.equals(function.apply(element), expectedValue));
+  }
+
+  /**
+   * Filters the iterable under test keeping only elements matching the given {@link Predicate}.
+   * <p>
+   * Example: check old employees whose age &gt; 100:
+   *
+   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
+   * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
+   * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
+   *
+   * List&lt;Employee&gt; employees = List.of(yoda, luke, obiwan);
+   *
+   * assertThat(employees).filteredOn(employee -&gt; employee.getAge() &gt; 100)
+   *                      .containsOnly(yoda, obiwan);</code></pre>
+   *
+   * @param predicate the filter predicate
+   * @return a new assertion object with the filtered iterable under test
+   * @throws IllegalArgumentException if the given predicate is {@code null}.
+   */
+  @Override
+  public SELF filteredOn(Predicate<? super ELEMENT> predicate) {
+    checkArgument(predicate != null, "The filter predicate should not be null");
+    return internalFilteredOn(predicate::test);
   }
 
   /**
@@ -71,5 +106,18 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldHaveSize(actual, actualSize, expected));
+  }
+
+  /**
+   * Helper method that filters via Eclipse Collections to avoid creating any JCL collections.
+   *
+   * @param predicate The predicate to filter on.
+   * @return A new {@link AbstractRichIterableAssert} with the filtered values.
+   */
+  private SELF internalFilteredOn(org.eclipse.collections.api.block.predicate.Predicate<? super ELEMENT> predicate) {
+    checkArgument(predicate != null, "The filter predicate should not be null");
+    // TODO: In AbstractIterableAssert the withAssertionState method is package-private. Need to find out how to handle
+    //  this method or if we need to use it
+    return newAbstractIterableAssert(actual.select(predicate));//.withAssertionState(myself);
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
@@ -33,6 +33,13 @@ public class Assertions {
     // Do nothing
   }
 
+  /**
+   * Creates a new instance of {@link BagAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @param <T> The type of the elements in the bag
+   */
   public static <T> BagAssert<T> assertThat(Bag<T> actual) {
     return new BagAssert<>(actual);
   }

--- a/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
@@ -15,8 +15,10 @@
  */
 package org.assertj.eclipse.collections.api;
 
-import org.assertj.core.util.CheckReturnValue;
+import org.assertj.core.annotation.CheckReturnValue;
+import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.multimap.Multimap;
+import org.eclipse.collections.api.set.SetIterable;
 
 /**
  * Entry point for assertion methods for the Eclipse Collections library. Each method in this class is a static factory
@@ -31,6 +33,10 @@ public class Assertions {
     // Do nothing
   }
 
+  public static <T> BagAssert<T> assertThat(Bag<T> actual) {
+    return new BagAssert<>(actual);
+  }
+
   /**
    * Creates a new instance of {@link MultimapAssert}.
    *
@@ -41,5 +47,16 @@ public class Assertions {
    */
   public static <KEY, VALUE> MultimapAssert<KEY, VALUE> assertThat(Multimap<KEY, VALUE> actual) {
     return new MultimapAssert<>(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link SetIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @param <T> The type of the elements in the set
+   */
+  public static <T>SetIterableAssert<T> assertThat(SetIterable<T> actual) {
+    return new SetIterableAssert<>(actual);
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BDDAssertions.java
@@ -15,8 +15,10 @@
  */
 package org.assertj.eclipse.collections.api;
 
-import org.assertj.core.util.CheckReturnValue;
+import org.assertj.core.annotation.CheckReturnValue;
+import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.multimap.Multimap;
+import org.eclipse.collections.api.set.SetIterable;
 
 /**
  * Behavior-driven development style entry point for assertion methods for the Eclipse Collections library. Each method
@@ -32,6 +34,17 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
+   * Creates a new instance of {@link BagAssert}.
+   *
+   * @param actual the actual value.
+   * @return thre created assertion object.
+   * @param <T> THe type of the elements in the bag
+   */
+  public static <T> BagAssert<T> then(Bag<T> actual) {
+    return assertThat(actual);
+  }
+
+  /**
    * Creates a new instance of {@link MultimapAssert}.
    *
    * @param actual the actual value.
@@ -40,6 +53,17 @@ public class BDDAssertions extends Assertions {
    * @param <VALUE> The type of values in the BagMultimap
    */
   public static <KEY, VALUE> MultimapAssert<KEY, VALUE> then(Multimap<KEY, VALUE> actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link SetIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @param <T> The type of the elements in the set
+   */
+  public static <T> SetIterableAssert<T> then(SetIterable<T> actual) {
     return assertThat(actual);
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/BagAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BagAssert.java
@@ -20,6 +20,11 @@ import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.ImmutableBag;
 import org.eclipse.collections.api.factory.Bags;
 
+/**
+ * Assertion methods for the {@link Bag} interface.
+ *
+ * @param <ELEMENT> the type of elements stored in {@link Bag}.
+ */
 public class BagAssert<ELEMENT> extends AbstractRichIterableAssert<BagAssert<ELEMENT>, Bag<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
   public BagAssert(Bag<? extends ELEMENT> elements) {
     super(elements, BagAssert.class);

--- a/src/main/java/org/assertj/eclipse/collections/api/BagAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BagAssert.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import org.assertj.core.api.ObjectAssert;
+import org.eclipse.collections.api.bag.Bag;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+
+public class BagAssert<ELEMENT> extends AbstractRichIterableAssert<BagAssert<ELEMENT>, Bag<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
+  public BagAssert(Bag<? extends ELEMENT> elements) {
+    super(elements, BagAssert.class);
+  }
+
+  @Override
+  protected ObjectAssert<ELEMENT> toAssert(ELEMENT value) {
+    return new ObjectAssert<>(value);
+  }
+
+  @Override
+  protected BagAssert<ELEMENT> newAbstractIterableAssert(Iterable<? extends ELEMENT> iterable) {
+    ImmutableBag<? extends ELEMENT> elements = Bags.immutable.ofAll(iterable);
+    return new BagAssert<>(elements);
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
@@ -15,15 +15,30 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import org.assertj.core.annotation.CheckReturnValue;
 import org.assertj.core.api.SoftAssertionsProvider;
-import org.assertj.core.util.CheckReturnValue;
+import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.multimap.Multimap;
+import org.eclipse.collections.api.set.SetIterable;
 
 /**
  * Soft assertions implementations for Eclipse Collections types.
  */
 @CheckReturnValue
 public interface EclipseCollectionsSoftAssertionsProvider extends SoftAssertionsProvider {
+
+  /**
+   * Create a new, proxied instance of a {@link BagAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   * @param <T> The type of the elements in the bag
+   */
+  @SuppressWarnings("unchecked")
+  default <T> BagAssert<T> assertThat(Bag<T> actual) {
+    return this.proxy(BagAssert.class, Bag.class, actual);
+  }
+
   /**
    * Creates a new, proxied instance of a {@link MultimapAssert}
    *
@@ -35,5 +50,10 @@ public interface EclipseCollectionsSoftAssertionsProvider extends SoftAssertions
   @SuppressWarnings("unchecked")
   default <KEY, VALUE> MultimapAssert<KEY, VALUE> assertThat(Multimap<KEY, VALUE> actual) {
     return this.proxy(MultimapAssert.class, Multimap.class, actual);
+  }
+
+  @SuppressWarnings("unchecked")
+  default <T> SetIterableAssert<T> assertThat(SetIterable<T> actual) {
+    return this.proxy(SetIterableAssert.class, SetIterable.class, actual);
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
@@ -52,6 +52,13 @@ public interface EclipseCollectionsSoftAssertionsProvider extends SoftAssertions
     return this.proxy(MultimapAssert.class, Multimap.class, actual);
   }
 
+  /**
+   * Creates a new, proxied instance of a {@link SetIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   * @param <T> The type of the elements in the set
+   */
   @SuppressWarnings("unchecked")
   default <T> SetIterableAssert<T> assertThat(SetIterable<T> actual) {
     return this.proxy(SetIterableAssert.class, SetIterable.class, actual);

--- a/src/main/java/org/assertj/eclipse/collections/api/SetIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/SetIterableAssert.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import org.assertj.core.api.ObjectAssert;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.eclipse.collections.api.set.SetIterable;
+
+public class SetIterableAssert<ELEMENT> extends AbstractRichIterableAssert<SetIterableAssert<ELEMENT>, SetIterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
+  public SetIterableAssert(SetIterable<? extends ELEMENT> elements) {
+    super(elements, SetIterableAssert.class);
+  }
+
+  @Override
+  protected ObjectAssert<ELEMENT> toAssert(ELEMENT value) {
+    return new ObjectAssert<>(value);
+  }
+
+  @Override
+  protected SetIterableAssert<ELEMENT> newAbstractIterableAssert(Iterable<? extends ELEMENT> iterable) {
+    ImmutableSet<? extends ELEMENT> elements = Sets.immutable.ofAll(iterable);
+    return new SetIterableAssert<>(elements);
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/SetIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/SetIterableAssert.java
@@ -20,6 +20,11 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.api.set.SetIterable;
 
+/**
+ * Assertion methods for {@link SetIterable} interface.
+ *
+ * @param <ELEMENT> the type of elements stored in {@link SetIterable}.
+ */
 public class SetIterableAssert<ELEMENT> extends AbstractRichIterableAssert<SetIterableAssert<ELEMENT>, SetIterable<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
   public SetIterableAssert(SetIterable<? extends ELEMENT> elements) {
     super(elements, SetIterableAssert.class);

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -17,7 +17,9 @@
  * Test module for AssertJ Eclipse Collections
  */
 open module org.assertj.eclipse.collections.test {
+  exports org.assertj.eclipse.collections.api.bag;
   exports org.assertj.eclipse.collections.api.multimap;
+  exports org.assertj.eclipse.collections.api.set;
 
   requires org.assertj.eclipse.collections;
   requires org.assertj.core;

--- a/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_FilteredOn_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_FilteredOn_Test.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.bag;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.assertj.eclipse.collections.api.BagAssert;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+import org.junit.jupiter.api.Test;
+
+public class BagAssert_FilteredOn_Test {
+  @Test
+  void filteredOn_function_passes() {
+    ImmutableBag<String> bag = Bags.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).filteredOn(s -> s.charAt(0), 'T')
+      .hasSize(2)
+      .containsOnly("TOS", "TNG"));
+  }
+
+  @Test
+  void filteredOn_function_nullFunction_throwsException() {
+    ImmutableBag<String> bag = Bags.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(() -> new BagAssert<>(bag).filteredOn((Function) null, 'T'))
+      .withMessageContaining("The filter function should not be null");
+  }
+
+  @Test
+  void filteredOn_predicate_passes() {
+    ImmutableBag<String> bag = Bags.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).filteredOn(s -> s.startsWith("T"))
+      .hasSize(2)
+      .containsOnly("TOS", "TNG"));
+  }
+
+  @Test
+  void filteredOn_predicate_nullPredicate_throwsException() {
+    ImmutableBag<String> bag = Bags.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(() -> new BagAssert<>(bag).filteredOn((Predicate) null))
+      .withMessageContaining("The filter predicate should not be null");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasSize_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasSize_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.bag;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BagAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+import org.junit.jupiter.api.Test;
+
+public class BagAssert_HasSize_Test {
+  @Test
+  void passes() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasSize(5));
+  }
+
+  @Test
+  void failsEmpty() {
+    ImmutableBag<String> bag = Bags.immutable.empty();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasSize(5))
+      .withMessageContaining(String.format("Expected size: %s but was: 0", 5));
+  }
+
+  @Test
+  void failsNullMultimap() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(null).hasSize(5))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @Test
+  void softAssertionPasses() {
+    ImmutableBag<String> bag = createBag();
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(bag).hasSize(5));
+  }
+
+  private static ImmutableBag<String> createBag() {
+    return Bags.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/multimap/MultimapAssert_IsNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/multimap/MultimapAssert_IsNullOrEmpty_Test.java
@@ -54,6 +54,6 @@ class MultimapAssert_IsNullOrEmpty_Test {
 
   @Test
   void softAssertionPassesNullMultimap() {
-    assertThatNoException().isThrownBy(() -> SoftAssertions.assertSoftly(softly -> softly.assertThat(null).isNullOrEmpty()));
+    assertThatNoException().isThrownBy(() -> SoftAssertions.assertSoftly(softly -> softly.assertThat((Multimap) null).isNullOrEmpty()));
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/api/set/SetAssert_HasSize_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/set/SetAssert_HasSize_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.set;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.SetIterableAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+public class SetAssert_HasSize_Test {
+  @Test
+  void passes() {
+    ImmutableSet<String> set = createSet();
+    assertThatNoException().isThrownBy(() -> new SetIterableAssert<>(set).hasSize(5));
+  }
+
+  @Test
+  void failsEmpty() {
+    ImmutableSet<String> set = Sets.immutable.empty();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new SetIterableAssert<>(set).hasSize(5))
+      .withMessageContaining(String.format("Expected size: %s but was: 0", 5));
+  }
+
+  @Test
+  void failsNullInput() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new SetIterableAssert<>(null).hasSize(5))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @Test
+  void softAssertionPasses() {
+    ImmutableSet<String> set = createSet();
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(set).hasSize(5));
+  }
+
+  private static ImmutableSet<String> createSet() {
+    return Sets.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/set/SetIterableAssert_FilteredOn_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/set/SetIterableAssert_FilteredOn_Test.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.set;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.assertj.eclipse.collections.api.SetIterableAssert;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+public class SetIterableAssert_FilteredOn_Test {
+  @Test
+  void filteredOn_function_passes() {
+    ImmutableSet<String> set = Sets.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatNoException().isThrownBy(() -> new SetIterableAssert<>(set).filteredOn(s -> s.charAt(0), 'T')
+      .hasSize(2)
+      .containsOnly("TOS", "TNG"));
+  }
+
+  @Test
+  void filteredOn_function_nullFunction_throwsException() {
+    ImmutableSet<String> set = Sets.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(() -> new SetIterableAssert<>(set).filteredOn((Function) null, 'T'))
+      .withMessageContaining("The filter function should not be null");
+  }
+
+  @Test
+  void filteredOn_predicate_passes() {
+    ImmutableSet<String> set = Sets.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatNoException().isThrownBy(() -> new SetIterableAssert<>(set).filteredOn(s -> s.startsWith("T"))
+      .hasSize(2)
+      .containsOnly("TOS", "TNG"));
+  }
+
+  @Test
+  void filteredOn_predicate_nullPredicate_throwsException() {
+    ImmutableSet<String> set = Sets.immutable.of("TOS", "TNG", "DS9", "VOY", "ENT");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(() -> new SetIterableAssert<>(set).filteredOn((Predicate) null))
+      .withMessageContaining("The filter predicate should not be null");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/set/SetIterableAssert_HasSize_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/set/SetIterableAssert_HasSize_Test.java
@@ -24,7 +24,7 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
-public class SetAssert_HasSize_Test {
+public class SetIterableAssert_HasSize_Test {
   @Test
   void passes() {
     ImmutableSet<String> set = createSet();


### PR DESCRIPTION
This PR adds the `AbstractRichIterableAssert` class. The `RichIterable` interface is the base type for most of the Eclipse Collections. This will be the jumping off point for most of the rest of the assertion development. I've started with two different concrete types that directly extend from `RichIterable`: `SetIterable` and `Bag`. 

The `AbstractRichIterableAssert` extends from AssertJ core's `AbstractIterableAssert`. This is because a `RichIterable` extends from the JDK `Iterable` type. This gives us a big advantage: any Eclipse Collection assertion immediately has a set of functioning assertions without any additional effort. They may not be the most efficient but they will function. This also gives us a great list of methods to examine for overriding to provide better EC support.

I've demonstrated this by overriding the `hasSize` method on `AbstractIterableAssert`. This is because a `RichIterable` has a dedicated `size()` method so there is no need to iterate the collection to get the size. This makes the assertion faster and provides a dedicated hook for Eclipse Collections in the `AbstractRichIterableAssert` type. I expected many if not most of the `AbstractIterableAssert` methods to be overridden in this process. Once done, we can discuss whether we want to keep extending from the core type.