### PR TITLE
Add Size Methods to AbstractRichIterable

### DIFF
--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -15,6 +15,7 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
@@ -164,6 +165,17 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldHaveSizeGreaterThanOrEqualTo(actual, actualSize, boundary));
+  }
+
+  @Override
+  public void isEmpty() {
+    isNotNull();
+
+    if (actual.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(shouldBeEmpty(actual));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -120,6 +120,7 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    *
    * @param other the array to compare the size of the actual RichIterable with.
    * @return {@code this} assertion object.
+   * @throws AssertionError if the provided array is {@code null}.
    * @throws AssertionError if the size of the actual RichIterable does not match the size of the given array or if the given array is {@code null}.
    */
   @Override

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -17,6 +17,7 @@ package org.assertj.eclipse.collections.api;
 
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
+import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.util.Objects;
@@ -134,6 +135,35 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldHaveSizeGreaterThan(actual, actualSize, boundary));
+  }
+
+  /**
+   * Verifies that the number of values in the actual group is greater than or equal to the given boundary.
+   * <p>
+   * Example:
+   * <pre>{@code // assertions will pass
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeGreaterThanOrEqualTo(3);
+   * assertThat(Lists.immutable.of("TNG", "DS9")).hasSizeGreaterThanOrEqualTo(1);
+   *
+   * // assertions will fail
+   * assertThat(Lists.immutable.of("TNG", "DS9")).hasSizeGreaterThanOrEqualTo(3);
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeGreaterThanOrEqualTo(4);
+   * }</pre>
+   *
+   * @param boundary the given value to compare the actual size to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the number of values of the actual group is not greater than or equal to the boundary.
+   */
+  @Override
+  public SELF hasSizeGreaterThanOrEqualTo(int boundary) {
+    isNotNull();
+
+    int actualSize = actual.size();
+    if (actualSize >= boundary) {
+      return myself;
+    }
+
+    throw assertionError(shouldHaveSizeGreaterThanOrEqualTo(actual, actualSize, boundary));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -16,6 +16,7 @@
 package org.assertj.eclipse.collections.api;
 
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
+import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.util.Objects;
@@ -106,6 +107,33 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldHaveSize(actual, actualSize, expected));
+  }
+
+  /**
+   * Verifies that the number of values in the actual RichIterable is greater than the given boundary.
+   * <p>
+   * Example:
+   * <pre>{@code // assertion will pass
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeGreaterThan(2);
+   *
+   * // assertion will fail
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeGreaterThan(3);
+   * }</pre>
+   *
+   * @param boundary the given value to compare the actual size to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the number of values of the actual iterable is not greater than the boundary.
+   */
+  @Override
+  public SELF hasSizeGreaterThan(int boundary) {
+    isNotNull();
+
+    int actualSize = actual.size();
+    if (actualSize > boundary) {
+      return myself;
+    }
+
+    throw assertionError(shouldHaveSizeGreaterThan(actual, actualSize, boundary));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -167,6 +167,9 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     throw assertionError(shouldHaveSizeGreaterThanOrEqualTo(actual, actualSize, boundary));
   }
 
+  /**
+   * Verifies that the actual RichIterable is empty.
+   */
   @Override
   public void isEmpty() {
     isNotNull();

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -21,6 +21,7 @@ import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
 import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
+import static org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo.shouldHaveSizeLessThanOrEqualTo;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
@@ -196,6 +197,35 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldHaveSizeLessThan(actual, actualSize, boundary));
+  }
+
+  /**
+   * Verifies that the number of values in the actual RichIterable is less than or equal to the given boundary.
+   * <p>
+   * Example:
+   * <pre>{@code
+   * // assertions will pass
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeLessThanOrEqualTo(5)
+   *                                   .hasSizeLessThanOrEqualTo(3);
+   *
+   * // assertion will fail
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeLessThanOrEqualTo(2);
+   * }</pre>
+   *
+   * @param boundary the given value to compare the actual size to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the number of values of the actual RichIterable is not less than or equal to the boundary.
+   */
+  @Override
+  public SELF hasSizeLessThanOrEqualTo(int boundary) {
+    isNotNull();
+
+    int actualSize = actual.size();
+    if (actualSize <= boundary) {
+      return myself;
+    }
+
+    throw assertionError(shouldHaveSizeLessThanOrEqualTo(actual, actualSize, boundary));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -15,16 +15,20 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static org.assertj.core.error.ShouldBeAnArray.shouldBeAnArray;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
+import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
 import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
 import static org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo.shouldHaveSizeLessThanOrEqualTo;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.core.util.IterableUtil.sizeOf;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
+import java.lang.reflect.Array;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -83,6 +87,56 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
   public SELF filteredOn(Predicate<? super ELEMENT> predicate) {
     checkArgument(predicate != null, "The filter predicate should not be null");
     return internalFilteredOn(predicate::test);
+  }
+
+  /**
+   * Verifies that the size of the actual RichIterable is equal to the size of the given iterable.
+   *
+   * @param other the iterable to compare the size of the actual RichIterable with.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given iterable is {@code null}.
+   * @throws AssertionError if the size of the actual RichIterable is not equal to the size of the given iterable.
+   */
+  @Override
+  public SELF hasSameSizeAs(Iterable<?> other) {
+    isNotNull();
+
+    final int otherSize;
+    if (other instanceof RichIterable<?> richIterable) {
+      otherSize = richIterable.size();
+    } else {
+      otherSize = sizeOf(other);
+    }
+
+    int actualSize = actual.size();
+    if (actualSize == otherSize) {
+      return myself;
+    }
+    throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+  }
+
+  /**
+   * Verifies that the size of the actual RichIterable matches the size of the given array.
+   *
+   * @param other the array to compare the size of the actual RichIterable with.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the size of the actual RichIterable does not match the size of the given array or if the given array is {@code null}.
+   */
+  @Override
+  public SELF hasSameSizeAs(Object other) {
+    isNotNull();
+
+    if (!(other != null && other.getClass().isArray())) {
+      throw assertionError(shouldBeAnArray(other));
+    }
+
+    int otherSize = Array.getLength(other);
+    int actualSize = actual.size();
+    if (actualSize == otherSize) {
+      return myself;
+    }
+
+    throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -20,6 +20,7 @@ import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
+import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
@@ -167,6 +168,34 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldHaveSizeGreaterThanOrEqualTo(actual, actualSize, boundary));
+  }
+
+  /**
+   * Verifies that the number of values in the actual RichIterable is less than the given boundary.
+   * <p>
+   * Example:
+   * <pre>{@code
+   * // assertion will pass
+   * assertThat(Lists.immutable.of(1, 2, 3)).hasSizeLessThan(4);
+   *
+   * // assertion will fail
+   * assertThat(Lists.immutable.of(1, 2, 3)).hasSizeLessThan(3);
+   * }</pre>
+   *
+   * @param boundary the given value to compare the actual size to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the number of values of the actual RichIterable is not less than the boundary.
+   */
+  @Override
+  public SELF hasSizeLessThan(int boundary) {
+    isNotNull();
+
+    int actualSize = actual.size();
+    if (actualSize < boundary) {
+      return myself;
+    }
+
+    throw assertionError(shouldHaveSizeLessThan(actual, actualSize, boundary));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.assertj.core.annotation.CheckReturnValue;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.eclipse.collections.api.RichIterable;
@@ -61,6 +62,7 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
   }
 
   @Override
+  @CheckReturnValue
   public <T> SELF filteredOn(Function<? super ELEMENT, T> function, T expectedValue) {
     checkArgument(function != null, "The filter function should not be null");
     return internalFilteredOn(element -> Objects.equals(function.apply(element), expectedValue));
@@ -69,22 +71,23 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
   /**
    * Filters the iterable under test keeping only elements matching the given {@link Predicate}.
    * <p>
-   * Example: check old employees whose age &gt; 100:
+   * Example: check crew members whose pips > 2:
    *
-   * <pre><code class='java'> Employee yoda   = new Employee(1L, new Name("Yoda"), 800);
-   * Employee obiwan = new Employee(2L, new Name("Obiwan"), 800);
-   * Employee luke   = new Employee(3L, new Name("Luke", "Skywalker"), 26);
+   * <pre>{@code CrewMember picard   = new CrewMember(1L, new Name("Picard"), 4);
+   * CrewMember riker = new CrewMember(2L, new Name("Riker"), 3);
+   * CrewMember crusher   = new CrewMember(3L, new Name("Wesley", "Crusher"), 1);
    *
-   * List&lt;Employee&gt; employees = List.of(yoda, luke, obiwan);
+   * ImmutableList<CrewMember> crew = Lists.immutable.of(picard, crusher, riker);
    *
-   * assertThat(employees).filteredOn(employee -&gt; employee.getAge() &gt; 100)
-   *                      .containsOnly(yoda, obiwan);</code></pre>
+   * assertThat(crew).filteredOn(crewMember -> crewMember.getPips() > 2)
+   *                      .containsOnly(picard, riker);}</pre>
    *
    * @param predicate the filter predicate
    * @return a new assertion object with the filtered iterable under test
    * @throws IllegalArgumentException if the given predicate is {@code null}.
    */
   @Override
+  @CheckReturnValue
   public SELF filteredOn(Predicate<? super ELEMENT> predicate) {
     checkArgument(predicate != null, "The filter predicate should not be null");
     return internalFilteredOn(predicate::test);
@@ -148,11 +151,11 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    * <pre>{@code
    * // assertions will pass
    * assertThat(Sets.immutable.of("TNG", "DS9")).hasSize(2);
-   * assertThat(Bags.immutable.of(1, 2, 3)).hasSize(3);
+   * assertThat(Bags.immutable.of("TNG", "DS9", "VOY")).hasSize(3);
    *
    * // assertions will fail
    * assertThat(Sets.immutable.empty()).hasSize(1);
-   * assertThat(Bags.immutable.of(1, 2, 3)).hasSize(2);
+   * assertThat(Bags.immutable.of("TNG", "DS9", "VOY")).hasSize(2);
    * }</pre>
    *
    * @param expected the expected number of values in the actual collection.
@@ -176,12 +179,12 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    * <p>
    * Example:
    * <pre><code class='java'> // assertions will pass
-   * assertThat(Arrays.asList(1, 2, 3)).hasSizeBetween(2, 3)
-   *                                   .hasSizeBetween(3, 4)
-   *                                   .hasSizeBetween(3, 3);
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeBetween(2, 3)
+   *                                               .hasSizeBetween(3, 4)
+   *                                               .hasSizeBetween(3, 3);
    *
    * // assertion will fail
-   * assertThat(Arrays.asList(1, 2, 3)).hasSizeBetween(4, 6);</code></pre>
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeBetween(4, 6);</code></pre>
    *
    * @param lowerBoundary  the lower boundary compared to which actual size should be greater than or equal to.
    * @param higherBoundary the higher boundary compared to which actual size should be less than or equal to.
@@ -268,10 +271,10 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    * Example:
    * <pre>{@code
    * // assertion will pass
-   * assertThat(Lists.immutable.of(1, 2, 3)).hasSizeLessThan(4);
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeLessThan(4);
    *
    * // assertion will fail
-   * assertThat(Lists.immutable.of(1, 2, 3)).hasSizeLessThan(3);
+   * assertThat(Lists.immutable.of("TOS", "TNG", "DS9")).hasSizeLessThan(3);
    * }</pre>
    *
    * @param boundary the given value to compare the actual size to.

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -20,6 +20,7 @@ import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
+import static org.assertj.core.error.ShouldHaveSizeBetween.shouldHaveSizeBetween;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
 import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
@@ -168,6 +169,41 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldHaveSize(actual, actualSize, expected));
+  }
+
+  /**
+   * Verifies that the number of values in the actual RichIterable is between the given boundaries (inclusive).
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(Arrays.asList(1, 2, 3)).hasSizeBetween(2, 3)
+   *                                   .hasSizeBetween(3, 4)
+   *                                   .hasSizeBetween(3, 3);
+   *
+   * // assertion will fail
+   * assertThat(Arrays.asList(1, 2, 3)).hasSizeBetween(4, 6);</code></pre>
+   *
+   * @param lowerBoundary  the lower boundary compared to which actual size should be greater than or equal to.
+   * @param higherBoundary the higher boundary compared to which actual size should be less than or equal to.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the number of values of the actual RichIterable is not between the boundaries.
+   */
+  @Override
+  public SELF hasSizeBetween(int lowerBoundary, int higherBoundary) {
+    isNotNull();
+
+    if (!(higherBoundary >= lowerBoundary)) {
+      throw new IllegalArgumentException("The higher boundary <%s> must be greater than the lower boundary <%s>.".formatted(
+        higherBoundary,
+        lowerBoundary));
+    }
+
+    int actualSize = actual.size();
+    if (actualSize >= lowerBoundary && actualSize <= higherBoundary) {
+      return myself;
+    }
+
+    throw assertionError(shouldHaveSizeBetween(actual, actualSize, lowerBoundary, higherBoundary));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -16,6 +16,7 @@
 package org.assertj.eclipse.collections.api;
 
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
+import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
@@ -199,6 +200,20 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldNotBeEmpty());
+  }
+
+  /**
+   * Verifies that the actual RichIterable is null or empty.
+   *
+   * @throws AssertionError if the actual RichIterable is not null or not empty.
+   */
+  @Override
+  public void isNullOrEmpty() {
+    if (actual == null || actual.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(shouldBeNullOrEmpty(actual));
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -194,7 +194,7 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
   public SELF isNotEmpty() {
     isNotNull();
 
-    if (!actual.isEmpty()) {
+    if (actual.notEmpty()) {
       return myself;
     }
 

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -19,6 +19,7 @@ import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
+import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.util.Objects;
@@ -169,6 +170,8 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
 
   /**
    * Verifies that the actual RichIterable is empty.
+   *
+   * @throws AssertionError if the actual RichIterable is not empty.
    */
   @Override
   public void isEmpty() {
@@ -179,6 +182,23 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldBeEmpty(actual));
+  }
+
+  /**
+   * Verifies that the actual RichIterable is not empty.
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual RichIterable is empty.
+   */
+  @Override
+  public SELF isNotEmpty() {
+    isNotNull();
+
+    if (!actual.isEmpty()) {
+      return myself;
+    }
+
+    throw assertionError(shouldNotBeEmpty());
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
@@ -46,6 +46,13 @@ public class Assertions {
     return new BagAssert<>(actual);
   }
 
+  /**
+   * Creates a new instance of {@link ListIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @param <T> The type of the elements in the list
+   */
   public static <T> ListIterableAssert<T> assertThat(ListIterable<T> actual) {
     return new ListIterableAssert<>(actual);
   }
@@ -73,6 +80,13 @@ public class Assertions {
     return new SetIterableAssert<>(actual);
   }
 
+  /**
+   * Creates a new instance of {@link StackIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @param <T> The type of the elements in the stack
+   */
   public static <T> StackIterableAssert<T> assertThat(StackIterable<T> actual) {
     return new StackIterableAssert<>(actual);
   }

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSameSizeAs_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSameSizeAs_Test.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.List;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.factory.Lists;
+
+class AbstractRichIterableAssert_HasSameSizeAs_Test {
+
+  @RichIterableParameterizedTest
+  void passesRichIterable(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(Lists.immutable.of("a", "b", "c", "d", "e")));
+  }
+
+  @RichIterableParameterizedTest
+  void passesJcfIterable(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(List.of("a", "b", "c", "d", "e")));
+  }
+
+  @RichIterableParameterizedTest
+  void failsRichIterableDifferentSize(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(Lists.immutable.of("a", "b", "c")))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @RichIterableParameterizedTest
+  void failsJcfIterableDifferentSize(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(List.of("a", "b", "c")))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @RichIterableParameterizedTest
+  void failsRichIterableNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(Lists.immutable.of("a", "b", "c", "d", "e")))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void failsJcfIterableNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(List.of("a", "b", "c", "d", "e")))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPassesRichIterable(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(Lists.immutable.of("a", "b", "c", "d", "e")));
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPassesJcfIterable(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(List.of("a", "b", "c", "d", "e")));
+  }
+
+  @RichIterableParameterizedTest
+  void passesArray(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(new String[]{"a", "b", "c", "d", "e"}));
+  }
+
+  @RichIterableParameterizedTest
+  void failsArrayDifferentSize(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(new String[]{"a", "b", "c"}))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @RichIterableParameterizedTest
+  void failsArrayNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(new String[]{"a", "b", "c", "d", "e"}))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPassesArray(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(new String[]{"a", "b", "c", "d", "e"}));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeBetween_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeBetween_Test.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+class AbstractRichIterableAssert_HasSizeBetween_Test {
+
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeBetween(3, 7));
+  }
+
+  @RichIterableParameterizedTest
+  void passesLowerBound(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeBetween(5, 7));
+  }
+
+  @RichIterableParameterizedTest
+  void passesUpperBound(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeBetween(3, 5));
+  }
+
+  @RichIterableParameterizedTest
+  void failsBelowLowerBound(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeBetween(7, 10))
+      .withMessageContaining("Expected size to be between");
+  }
+
+  @RichIterableParameterizedTest
+  void failsAboveUpperBound(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeBetween(1, 3))
+      .withMessageContaining("Expected size to be between");
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().hasSizeBetween(3, 5))
+      .withMessageContaining("Expected size to be between");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSizeBetween(3, 5))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSizeBetween(3, 7));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThanOrEqualTo_Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.assertj.eclipse.collections.api.richiterable;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThanOrEqualTo_Test.java
@@ -1,0 +1,39 @@
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_HasSizeGreaterThanOrEqualTo_Test {
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThanOrEqualTo(3));
+  }
+
+  @RichIterableParameterizedTest
+  void passesEquals(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThanOrEqualTo(5));
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().hasSizeGreaterThanOrEqualTo(3))
+      .withMessageContaining(String.format("to be greater than or equal to %s but was 0", 3));
+  }
+
+  @RichIterableParameterizedTest
+  void failsLessThan(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThanOrEqualTo(7))
+      .withMessageContaining(String.format("to be greater than or equal to %s but was 5", 7));
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThanOrEqualTo(2));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThan_Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.assertj.eclipse.collections.api.richiterable;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeGreaterThan_Test.java
@@ -1,0 +1,40 @@
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_HasSizeGreaterThan_Test {
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThan(3));
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().hasSizeGreaterThan(3))
+      .withMessageContaining(String.format("to be greater than %s but was 0", 3));
+  }
+
+  @RichIterableParameterizedTest
+  void failsEquals(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThan(5))
+      .withMessageContaining(String.format("to be greater than %s but was 5", 5));
+  }
+
+  @RichIterableParameterizedTest
+  void failsLessThan(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThan(7))
+      .withMessageContaining(String.format("to be greater than %s but was 5", 7));
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSizeGreaterThan(2));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeLessThanOrEqualTo_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_HasSizeLessThanOrEqualTo_Test {
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThanOrEqualTo(7));
+  }
+
+  @RichIterableParameterizedTest
+  void passesEquals(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThanOrEqualTo(5));
+  }
+
+  @RichIterableParameterizedTest
+  void passesEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().hasSizeLessThanOrEqualTo(3));
+  }
+
+  @RichIterableParameterizedTest
+  void failsGreaterThan(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThanOrEqualTo(3))
+      .withMessageContaining(String.format("to be less than or equal to %s but was 5", 3));
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThanOrEqualTo(7));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeLessThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSizeLessThan_Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_HasSizeLessThan_Test {
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThan(7));
+  }
+
+  @RichIterableParameterizedTest
+  void passesEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().hasSizeLessThan(3));
+  }
+
+  @RichIterableParameterizedTest
+  void failsEquals(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThan(5))
+      .withMessageContaining(String.format("to be less than %s but was 5", 5));
+  }
+
+  @RichIterableParameterizedTest
+  void failsGreaterThan(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThan(3))
+      .withMessageContaining(String.format("to be less than %s but was 5", 3));
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSizeLessThan(7));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_IsEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_IsEmpty_Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+class AbstractRichIterableAssert_IsEmpty_Test {
+
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().isEmpty());
+  }
+
+  @RichIterableParameterizedTest
+  void failsNonEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").isEmpty())
+      .withMessageContaining("Expecting empty but was:");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().isEmpty())
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly).isEmpty());
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_IsNotEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_IsNotEmpty_Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+class AbstractRichIterableAssert_IsNotEmpty_Test {
+
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").isNotEmpty());
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().isNotEmpty())
+      .withMessageContaining("Expecting actual not to be empty");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().isNotEmpty())
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").isNotEmpty());
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_IsNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_IsNullOrEmpty_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+class AbstractRichIterableAssert_IsNullOrEmpty_Test {
+
+  @RichIterableParameterizedTest
+  void passesEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().isNullOrEmpty());
+  }
+
+  @RichIterableParameterizedTest
+  void passesNull(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromNull().isNullOrEmpty());
+  }
+
+  @RichIterableParameterizedTest
+  void failsNonEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").isNullOrEmpty())
+      .withMessageContaining("Expecting null or empty but was:");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly).isNullOrEmpty());
+  }
+}


### PR DESCRIPTION
I'm beginning to override the methods in `AbstractIterableAssert` that make sense in `AbstractRichIterable`. I've started with all of the remaining size methods. Since `RichIterable` has a `size()` method, we can get benefits by using it rather than iterating through the collection with a stream. 

I did this by first adding tests to validate that it already worked with the code found in `AsbtractIterableAssert`. Then I implemented the method in `AbstractRichIterableAssert` using Eclipse Collections code and made sure the tests still pass. This will be the pattern going forward.