### PR TITLE
Introduce Skeleton for PrimitiveIterable assertions

### DIFF
--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractPrimitiveIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractPrimitiveIterableAssert.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldBeAnArray.shouldBeAnArray;
+import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
+import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
+import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
+import static org.assertj.core.error.ShouldHaveSizeBetween.shouldHaveSizeBetween;
+import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
+import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
+import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
+import static org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo.shouldHaveSizeLessThanOrEqualTo;
+import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.eclipse.collections.util.RichIterableUtil.sizeOf;
+
+import java.lang.reflect.Array;
+
+import org.assertj.core.api.AbstractAssert;
+import org.eclipse.collections.api.PrimitiveIterable;
+
+/**
+ * Base class for all assertions for the {@link PrimitiveIterable} interface.
+ *
+ * @param <SELF>   the "self" type of this assertion class. Please read &quot;<a href="https://bit.ly/1IZIRcY"
+ *                 target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
+ *                 for more details.
+ * @param <ACTUAL> the type of the "actual" value.
+ */
+public abstract class AbstractPrimitiveIterableAssert<SELF extends AbstractPrimitiveIterableAssert<SELF, ACTUAL>, ACTUAL extends PrimitiveIterable> extends AbstractAssert<SELF, ACTUAL> {
+
+  protected AbstractPrimitiveIterableAssert(ACTUAL actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  public SELF hasSameSizeAs(PrimitiveIterable other) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int otherSize = sizeOf(other);
+      int actualSize = actual.size();
+      if (actualSize == otherSize) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+    });
+  }
+
+  public SELF hasSameSizeAs(Iterable<?> other) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int otherSize = sizeOf(other);
+      int actualSize = actual.size();
+      if (actualSize == otherSize) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+    });
+  }
+
+  public SELF hasSameSizeAs(Object other) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      if (!(other != null && other.getClass().isArray())) {
+        throw assertionError(shouldBeAnArray(other));
+      }
+
+      int otherSize = Array.getLength(other);
+      int actualSize = actual.size();
+      if (actualSize == otherSize) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+    });
+  }
+
+  public SELF hasSize(int expectedSize) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualSize = actual.size();
+      if (actualSize == expectedSize) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSize(actual, actualSize, expectedSize));
+    });
+  }
+
+  public SELF hasSizeBetween(int lowerBoundary, int higherBoundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      if (!(higherBoundary >= lowerBoundary)) {
+        throw new IllegalArgumentException("The higher boundary <%s> must be greater than the lower boundary <%s>.".formatted(
+          higherBoundary,
+          lowerBoundary));
+      }
+
+      int actualSize = actual.size();
+      if (actualSize >= lowerBoundary && actualSize <= higherBoundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSizeBetween(actual, actualSize, lowerBoundary, higherBoundary));
+    });
+  }
+
+  public SELF hasSizeGreaterThan(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualSize = actual.size();
+      if (actualSize > boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSizeGreaterThan(actual, actualSize, boundary));
+    });
+  }
+
+  public SELF hasSizeGreaterThanOrEqualTo(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualSize = actual.size();
+      if (actualSize >= boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSizeGreaterThanOrEqualTo(actual, actualSize, boundary));
+    });
+  }
+
+  public SELF hasSizeLessThan(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualSize = actual.size();
+      if (actualSize < boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSizeLessThan(actual, actualSize, boundary));
+    });
+  }
+
+  public SELF hasSizeLessThanOrEqualTo(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualSize = actual.size();
+      if (actualSize <= boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSizeLessThanOrEqualTo(actual, actualSize, boundary));
+    });
+  }
+
+  public void isEmpty() {
+    executeAssertion(() -> {
+      isNotNull();
+
+      if (actual.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldBeEmpty(actual));
+    });
+  }
+
+  public SELF isNotEmpty() {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      if (actual.notEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotBeEmpty());
+    });
+  }
+
+  public void isNullOrEmpty() {
+    executeAssertion(() -> {
+      if (actual == null || actual.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldBeNullOrEmpty(actual));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
@@ -16,6 +16,14 @@
 package org.assertj.eclipse.collections.api;
 
 import org.assertj.core.annotation.CheckReturnValue;
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.api.DoubleIterable;
+import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.api.IntIterable;
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.multimap.Multimap;
@@ -26,7 +34,6 @@ import org.eclipse.collections.api.stack.StackIterable;
  * Entry point for assertion methods for the Eclipse Collections library. Each method in this class is a static factory
  * for a type-specific assertion object.
  */
-@CheckReturnValue
 public class Assertions {
   /**
    * Creates a new {@link Assertions}.
@@ -42,8 +49,75 @@ public class Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the bag
    */
+  @CheckReturnValue
   public static <T> BagAssert<T> assertThat(Bag<T> actual) {
     return new BagAssert<>(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link BooleanIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static BooleanIterableAssert assertThat(BooleanIterable actual) {
+    return new BooleanIterableAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link ByteIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static ByteIterableAssert assertThat(ByteIterable actual) {
+    return new ByteIterableAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link CharIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static CharIterableAssert assertThat(CharIterable actual) {
+    return new CharIterableAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link DoubleIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static DoubleIterableAssert assertThat(DoubleIterable actual) {
+    return new DoubleIterableAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link FloatIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static FloatIterableAssert assertThat(FloatIterable actual) {
+    return new FloatIterableAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link IntIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static IntIterableAssert assertThat(IntIterable actual) {
+    return new IntIterableAssert(actual);
   }
 
   /**
@@ -53,8 +127,20 @@ public class Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the list
    */
+  @CheckReturnValue
   public static <T> ListIterableAssert<T> assertThat(ListIterable<T> actual) {
     return new ListIterableAssert<>(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link LongIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static LongIterableAssert assertThat(LongIterable actual) {
+    return new LongIterableAssert(actual);
   }
 
   /**
@@ -65,6 +151,7 @@ public class Assertions {
    * @param <KEY> The type of keys in the BagMultimap
    * @param <VALUE> The type of values in the BagMultimap
    */
+  @CheckReturnValue
   public static <KEY, VALUE> MultimapAssert<KEY, VALUE> assertThat(Multimap<KEY, VALUE> actual) {
     return new MultimapAssert<>(actual);
   }
@@ -76,8 +163,20 @@ public class Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the set
    */
+  @CheckReturnValue
   public static <T> SetIterableAssert<T> assertThat(SetIterable<T> actual) {
     return new SetIterableAssert<>(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link ShortIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static ShortIterableAssert assertThat(ShortIterable actual) {
+    return new ShortIterableAssert(actual);
   }
 
   /**
@@ -87,6 +186,7 @@ public class Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the stack
    */
+  @CheckReturnValue
   public static <T> StackIterableAssert<T> assertThat(StackIterable<T> actual) {
     return new StackIterableAssert<>(actual);
   }

--- a/src/main/java/org/assertj/eclipse/collections/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BDDAssertions.java
@@ -16,6 +16,14 @@
 package org.assertj.eclipse.collections.api;
 
 import org.assertj.core.annotation.CheckReturnValue;
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.api.DoubleIterable;
+import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.api.IntIterable;
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.multimap.Multimap;
@@ -26,7 +34,6 @@ import org.eclipse.collections.api.stack.StackIterable;
  * Behavior-driven development style entry point for assertion methods for the Eclipse Collections library. Each method
  * in this class is a static factory for a type-specific assertion object.
  */
-@CheckReturnValue
 public class BDDAssertions extends Assertions {
   /**
    * Creates a new <code>{@link BDDAssertions}</code>.
@@ -42,7 +49,74 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the bag
    */
+  @CheckReturnValue
   public static <T> BagAssert<T> then(Bag<T> actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link BooleanIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static BooleanIterableAssert then(BooleanIterable actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link ByteIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static ByteIterableAssert then(ByteIterable actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link CharIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static CharIterableAssert then(CharIterable actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link DoubleIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static DoubleIterableAssert then(DoubleIterable actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link FloatIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static FloatIterableAssert then(FloatIterable actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link IntIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static IntIterableAssert then(IntIterable actual) {
     return assertThat(actual);
   }
 
@@ -53,7 +127,19 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the list
    */
+  @CheckReturnValue
   public static <T> ListIterableAssert<T> then(ListIterable<T> actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link LongIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static LongIterableAssert then(LongIterable actual) {
     return assertThat(actual);
   }
 
@@ -65,6 +151,7 @@ public class BDDAssertions extends Assertions {
    * @param <KEY> The type of keys in the BagMultimap
    * @param <VALUE> The type of values in the BagMultimap
    */
+  @CheckReturnValue
   public static <KEY, VALUE> MultimapAssert<KEY, VALUE> then(Multimap<KEY, VALUE> actual) {
     return assertThat(actual);
   }
@@ -76,7 +163,19 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the set
    */
+  @CheckReturnValue
   public static <T> SetIterableAssert<T> then(SetIterable<T> actual) {
+    return assertThat(actual);
+  }
+
+  /**
+   * Creates a new instance of {@link ShortIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  public static ShortIterableAssert then(ShortIterable actual) {
     return assertThat(actual);
   }
 
@@ -87,6 +186,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @param <T> The type of the elements in the stack
    */
+  @CheckReturnValue
   public static <T> StackIterableAssert<T> then(StackIterable<T> actual) {
     return assertThat(actual);
   }

--- a/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.factory.primitive.BooleanLists;
+
+public class BooleanIterableAssert extends AbstractPrimitiveIterableAssert<BooleanIterableAssert, BooleanIterable> {
+  public BooleanIterableAssert(BooleanIterable actual) {
+    super(actual, BooleanIterableAssert.class);
+  }
+
+  public BooleanIterableAssert contains(boolean... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      BooleanIterable notFound = BooleanLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.api.factory.primitive.ByteLists;
+
+public class ByteIterableAssert extends AbstractPrimitiveIterableAssert<ByteIterableAssert, ByteIterable> {
+
+  public ByteIterableAssert(ByteIterable actual) {
+    super(actual, ByteIterableAssert.class);
+  }
+
+  public ByteIterableAssert contains(byte... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ByteIterable notFound = ByteLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.api.factory.primitive.CharLists;
+
+public class CharIterableAssert extends AbstractPrimitiveIterableAssert<CharIterableAssert, CharIterable> {
+  public CharIterableAssert(CharIterable actual) {
+    super(actual, CharIterableAssert.class);
+  }
+
+  public CharIterableAssert contains(char... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      CharIterable notFound = CharLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.DoubleIterable;
+import org.eclipse.collections.api.factory.primitive.DoubleLists;
+
+public class DoubleIterableAssert extends AbstractPrimitiveIterableAssert<DoubleIterableAssert, DoubleIterable> {
+  public DoubleIterableAssert(DoubleIterable actual) {
+    super(actual, DoubleIterableAssert.class);
+  }
+
+  public DoubleIterableAssert contains(double... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      DoubleIterable notFound = DoubleLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
@@ -17,6 +17,14 @@ package org.assertj.eclipse.collections.api;
 
 import org.assertj.core.annotation.CheckReturnValue;
 import org.assertj.core.api.SoftAssertionsProvider;
+import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.api.DoubleIterable;
+import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.api.IntIterable;
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.multimap.Multimap;
@@ -26,67 +34,154 @@ import org.eclipse.collections.api.stack.StackIterable;
 /**
  * Soft assertions implementations for Eclipse Collections types.
  */
-@CheckReturnValue
 public interface EclipseCollectionsSoftAssertionsProvider extends SoftAssertionsProvider {
 
   /**
-   * Create a new, proxied instance of a {@link BagAssert}
+   * Create a new instance of a {@link BagAssert}
    *
    * @param actual the actual value
    * @return the created assertion object
    * @param <T> The type of the elements in the bag
    */
-  @SuppressWarnings("unchecked")
+  @CheckReturnValue
   default <T> BagAssert<T> assertThat(Bag<T> actual) {
-    return this.proxy(BagAssert.class, Bag.class, actual);
+    return soft(Assertions.assertThat(actual));
   }
 
   /**
-   * Creates a new, proxied instance of a {@link ListIterableAssert}
+   * Create a new instance of a {@link BooleanIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default BooleanIterableAssert assertThat(BooleanIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Create a new instance of a {@link ByteIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default ByteIterableAssert assertThat(ByteIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Create a new instance of a {@link CharIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default CharIterableAssert assertThat(CharIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Create a new instance of a {@link DoubleIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default DoubleIterableAssert assertThat(DoubleIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Create a new instance of a {@link FloatIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default FloatIterableAssert assertThat(FloatIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Create a new instance of a {@link IntIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default IntIterableAssert assertThat(IntIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Creates a new instance of a {@link ListIterableAssert}
    *
    * @param actual the actual value
    * @return the created assertion object
    * @param <T> The type of the elements in the list
    */
-  @SuppressWarnings("unchecked")
+  @CheckReturnValue
   default <T> ListIterableAssert<T> assertThat(ListIterable<T> actual) {
-    return this.proxy(ListIterableAssert.class, ListIterable.class, actual);
+    return soft(Assertions.assertThat(actual));
   }
 
   /**
-   * Creates a new, proxied instance of a {@link MultimapAssert}
+   * Creates a new instance of a {@link LongIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default LongIterableAssert assertThat(LongIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Creates a new instance of a {@link MultimapAssert}
    *
    * @param actual the path
    * @return the created assertion object
    * @param <KEY> The type of keys in the actual BagMultimap
    * @param <VALUE> The type of values in the actual BagMultimap
    */
-  @SuppressWarnings("unchecked")
+  @CheckReturnValue
   default <KEY, VALUE> MultimapAssert<KEY, VALUE> assertThat(Multimap<KEY, VALUE> actual) {
-    return this.proxy(MultimapAssert.class, Multimap.class, actual);
+    return soft(Assertions.assertThat(actual));
   }
 
   /**
-   * Creates a new, proxied instance of a {@link SetIterableAssert}
+   * Creates a new instance of a {@link SetIterableAssert}
    *
    * @param actual the actual value
    * @return the created assertion object
    * @param <T> The type of the elements in the set
    */
-  @SuppressWarnings("unchecked")
+  @CheckReturnValue
   default <T> SetIterableAssert<T> assertThat(SetIterable<T> actual) {
-    return this.proxy(SetIterableAssert.class, SetIterable.class, actual);
+    return soft(Assertions.assertThat(actual));
   }
 
   /**
-   * Creates a new, proxied instance of a {@link StackIterableAssert}
+   * Creates a new instance of a {@link ShortIterableAssert}
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   */
+  @CheckReturnValue
+  default ShortIterableAssert assertThat(ShortIterable actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Creates a new instance of a {@link StackIterableAssert}
    *
    * @param actual the actual value
    * @return the created assertion object
    * @param <T> The type of the elements in the stack
    */
-  @SuppressWarnings("unchecked")
+  @CheckReturnValue
   default <T> StackIterableAssert<T> assertThat(StackIterable<T> actual) {
-    return this.proxy(StackIterableAssert.class, StackIterable.class, actual);
+    return soft(Assertions.assertThat(actual));
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.api.factory.primitive.FloatLists;
+
+public class FloatIterableAssert extends AbstractPrimitiveIterableAssert<FloatIterableAssert, FloatIterable> {
+  public FloatIterableAssert(FloatIterable actual) {
+    super(actual, FloatIterableAssert.class);
+  }
+
+  public FloatIterableAssert contains(float... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      FloatIterable notFound = FloatLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.IntIterable;
+import org.eclipse.collections.api.factory.primitive.IntLists;
+
+public class IntIterableAssert extends AbstractPrimitiveIterableAssert<IntIterableAssert, IntIterable> {
+  public IntIterableAssert(IntIterable actual) {
+    super(actual, IntIterableAssert.class);
+  }
+
+  public IntIterableAssert contains(int... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      IntIterable notFound = IntLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.factory.primitive.LongLists;
+
+public class LongIterableAssert extends AbstractPrimitiveIterableAssert<LongIterableAssert, LongIterable> {
+  public LongIterableAssert(LongIterable actual) {
+    super(actual, LongIterableAssert.class);
+  }
+
+  public LongIterableAssert contains(long... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      LongIterable notFound = LongLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import static org.assertj.core.error.ShouldContain.shouldContain;
+
+import org.eclipse.collections.api.ShortIterable;
+import org.eclipse.collections.api.factory.primitive.ShortLists;
+
+public class ShortIterableAssert extends AbstractPrimitiveIterableAssert<ShortIterableAssert, ShortIterable> {
+  public ShortIterableAssert(ShortIterable actual) {
+    super(actual, ShortIterableAssert.class);
+  }
+
+  public ShortIterableAssert contains(short... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ShortIterable notFound = ShortLists.immutable.of(values).reject(actual::contains);
+
+      if (notFound.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/util/RichIterableUtil.java
+++ b/src/main/java/org/assertj/eclipse/collections/util/RichIterableUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.util;
+
+import org.assertj.core.util.IterableUtil;
+import org.eclipse.collections.api.PrimitiveIterable;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.multimap.Multimap;
+
+import static java.util.Objects.requireNonNull;
+
+public final class RichIterableUtil {
+  private RichIterableUtil() {
+    // Do nothing
+  }
+
+  public static int sizeOf(Iterable<?> iterable) {
+    requireNonNull(iterable, "Iterable must not be null");
+    if (iterable instanceof RichIterable<?> richIterable) {
+      return richIterable.size();
+    }
+    return IterableUtil.sizeOf(iterable);
+  }
+
+  public static int sizeOf(Multimap<?, ?> multimap) {
+    requireNonNull(multimap, "Multimap must not be null");
+    return multimap.size();
+  }
+
+  public static int sizeOf(PrimitiveIterable primitiveIterable) {
+    requireNonNull(primitiveIterable, "PrimitiveIterable must not be null");
+    return primitiveIterable.size();
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSameSizeAs_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSameSizeAs_Test.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.List;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.IntLists;
+
+class AbstractPrimitiveIterableAssert_HasSameSizeAs_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passesPrimitiveIterable(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSameSizeAs(IntLists.immutable.of(1, 2)));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesRichIterable(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSameSizeAs(Lists.immutable.of("TOS", "TNG")));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesJcfIterable(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSameSizeAs(List.of("TOS", "TNG")));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesArray(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSameSizeAs(new String[]{"TOS", "TNG"}));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsPrimitiveIterableDifferentSize(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSameSizeAs(IntLists.immutable.of(1, 2, 3)))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsRichIterableDifferentSize(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSameSizeAs(Lists.immutable.of("TOS", "TNG", "DS9")))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsJcfIterableDifferentSize(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSameSizeAs(List.of("TOS", "TNG", "DS9")))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsArrayDifferentSize(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSameSizeAs(new String[]{"TOS", "TNG", "DS9"}))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsPrimitiveIterableNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(IntLists.immutable.of(1, 2)))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsRichIterableNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(Lists.immutable.of("TOS", "TNG")))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsJcfIterableNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(List.of("TOS", "TNG")))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsArrayNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(new String[]{"TOS", "TNG"}))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPassesPrimitiveIterable(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSameSizeAs(IntLists.immutable.of(1, 2))));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPassesRichIterable(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSameSizeAs(Lists.immutable.of("TOS", "TNG"))));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPassesJcfIterable(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSameSizeAs(List.of("TOS", "TNG"))));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPassesArray(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSameSizeAs(new String[]{"TOS", "TNG"})));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeBetween_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeBetween_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_HasSizeBetween_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeBetween(1, 3));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesLowerBound(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeBetween(2, 4));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesUpperBound(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeBetween(1, 2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsBelowLowerBound(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSizeBetween(3, 5))
+      .withMessageContaining("Expected size to be between");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsAboveUpperBound(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSizeBetween(0, 1))
+      .withMessageContaining("Expected size to be between");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().hasSizeBetween(3, 5))
+      .withMessageContaining("Expected size to be between");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSizeBetween(3, 5))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSizeBetween(1, 3)));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeGreaterThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeGreaterThanOrEqualTo_Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_HasSizeGreaterThanOrEqualTo_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeGreaterThanOrEqualTo(1));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesEquals(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeGreaterThanOrEqualTo(2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().hasSizeGreaterThanOrEqualTo(3))
+      .withMessageContaining(String.format("to be greater than or equal to %s but was 0", 3));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsLessThan(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(1).hasSizeGreaterThanOrEqualTo(2))
+      .withMessageContaining(String.format("to be greater than or equal to %s but was 1", 2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSizeGreaterThanOrEqualTo(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSizeGreaterThanOrEqualTo(1)));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeGreaterThan_Test.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_HasSizeGreaterThan_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeGreaterThan(1));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().hasSizeGreaterThan(3))
+      .withMessageContaining(String.format("to be greater than %s but was 0", 3));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsEquals(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSizeGreaterThan(2))
+      .withMessageContaining(String.format("to be greater than %s but was 2", 2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsLessThan(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(1).hasSizeGreaterThan(2))
+      .withMessageContaining(String.format("to be greater than %s but was 1", 2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSizeGreaterThan(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSizeGreaterThan(1)));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeLessThanOrEqualTo_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_HasSizeLessThanOrEqualTo_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeLessThanOrEqualTo(3));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesEquals(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeLessThanOrEqualTo(2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().hasSizeLessThanOrEqualTo(3));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsGreaterThan(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSizeLessThanOrEqualTo(1))
+      .withMessageContaining(String.format("to be less than or equal to %s but was 2", 1));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSizeLessThanOrEqualTo(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSizeLessThanOrEqualTo(3)));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeLessThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSizeLessThan_Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_HasSizeLessThan_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSizeLessThan(3));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().hasSizeLessThan(3));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsEquals(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSizeLessThan(2))
+      .withMessageContaining(String.format("to be less than %s but was 2", 2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsGreaterThan(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSizeLessThan(1))
+      .withMessageContaining(String.format("to be less than %s but was 2", 1));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSizeLessThan(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSizeLessThan(3)));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSize_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_HasSize_Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_HasSize_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).hasSize(2));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().hasSize(0));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsWrongSize(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().hasSize(5))
+      .withMessageContaining(String.format("Expected size: %s but was: 0", 5));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSize(0))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsWrongSizeWithElements(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).hasSize(5))
+      .withMessageContaining(String.format("Expected size: %s but was: 2", 5));
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).hasSize(2)));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_IsEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_IsEmpty_Test.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_IsEmpty_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().isEmpty());
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNonEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).isEmpty())
+      .withMessageContaining("Expecting empty but was:");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().isEmpty())
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 0).isEmpty()));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_IsNotEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_IsNotEmpty_Test.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_IsNotEmpty_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passes(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromSize(2).isNotEmpty());
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().isNotEmpty())
+      .withMessageContaining("Expecting actual not to be empty");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNullInput(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().isNotEmpty())
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 2).isNotEmpty()));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_IsNullOrEmpty_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/AbstractPrimitiveIterableAssert_IsNullOrEmpty_Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractPrimitiveIterableAssert_IsNullOrEmpty_Test {
+
+  @PrimitiveIterableParameterizedTest
+  void passesEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().isNullOrEmpty());
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void passesNull(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromNull().isNullOrEmpty());
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void failsNonEmpty(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromSize(2).isNullOrEmpty())
+      .withMessageContaining("Expecting null or empty but was:");
+  }
+
+  @PrimitiveIterableParameterizedTest
+  void softAssertionPasses(PrimitiveIterableAssertFactory<?> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      SoftAssertions.assertSoftly(softly ->
+        assertFactory.softlyFromSize(softly, 0).isNullOrEmpty()));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableArgumentsProvider.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableArgumentsProvider.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import java.util.stream.Stream;
+
+import org.assertj.eclipse.collections.api.BooleanIterableAssert;
+import org.assertj.eclipse.collections.api.ByteIterableAssert;
+import org.assertj.eclipse.collections.api.CharIterableAssert;
+import org.assertj.eclipse.collections.api.DoubleIterableAssert;
+import org.assertj.eclipse.collections.api.FloatIterableAssert;
+import org.assertj.eclipse.collections.api.IntIterableAssert;
+import org.assertj.eclipse.collections.api.LongIterableAssert;
+import org.assertj.eclipse.collections.api.ShortIterableAssert;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.bag.primitive.MutableBooleanBag;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.factory.primitive.BooleanBags;
+import org.eclipse.collections.api.factory.primitive.BooleanLists;
+import org.eclipse.collections.api.factory.primitive.BooleanSets;
+import org.eclipse.collections.api.factory.primitive.BooleanStacks;
+import org.eclipse.collections.api.factory.primitive.ByteBags;
+import org.eclipse.collections.api.factory.primitive.ByteLists;
+import org.eclipse.collections.api.factory.primitive.ByteSets;
+import org.eclipse.collections.api.factory.primitive.ByteStacks;
+import org.eclipse.collections.api.factory.primitive.CharBags;
+import org.eclipse.collections.api.factory.primitive.CharLists;
+import org.eclipse.collections.api.factory.primitive.CharSets;
+import org.eclipse.collections.api.factory.primitive.CharStacks;
+import org.eclipse.collections.api.factory.primitive.DoubleBags;
+import org.eclipse.collections.api.factory.primitive.DoubleLists;
+import org.eclipse.collections.api.factory.primitive.DoubleSets;
+import org.eclipse.collections.api.factory.primitive.DoubleStacks;
+import org.eclipse.collections.api.factory.primitive.FloatBags;
+import org.eclipse.collections.api.factory.primitive.FloatLists;
+import org.eclipse.collections.api.factory.primitive.FloatSets;
+import org.eclipse.collections.api.factory.primitive.FloatStacks;
+import org.eclipse.collections.api.factory.primitive.IntBags;
+import org.eclipse.collections.api.factory.primitive.IntLists;
+import org.eclipse.collections.api.factory.primitive.IntSets;
+import org.eclipse.collections.api.factory.primitive.IntStacks;
+import org.eclipse.collections.api.factory.primitive.LongBags;
+import org.eclipse.collections.api.factory.primitive.LongLists;
+import org.eclipse.collections.api.factory.primitive.LongSets;
+import org.eclipse.collections.api.factory.primitive.LongStacks;
+import org.eclipse.collections.api.factory.primitive.ShortBags;
+import org.eclipse.collections.api.factory.primitive.ShortLists;
+import org.eclipse.collections.api.factory.primitive.ShortSets;
+import org.eclipse.collections.api.factory.primitive.ShortStacks;
+import org.eclipse.collections.api.list.primitive.MutableBooleanList;
+import org.eclipse.collections.api.multimap.MutableMultimap;
+import org.eclipse.collections.api.set.ImmutableSet;
+import org.eclipse.collections.api.set.primitive.MutableBooleanSet;
+import org.eclipse.collections.api.stack.primitive.MutableBooleanStack;
+import org.eclipse.collections.impl.factory.Multimaps;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.jupiter.params.support.ParameterDeclarations;
+
+class PrimitiveIterableArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<PrimitiveIterableParameterizedTest> {
+
+  private static final MutableMultimap<PrimitiveType, PrimitiveIterableAssertFactory<?>> FACTORIES_BY_TYPE;
+
+  static {
+    FACTORIES_BY_TYPE = Multimaps.mutable.list.empty();
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.BOOLEAN, booleanList(), booleanSet(), booleanBag(), booleanStack());
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.BYTE,    byteList(),    byteSet(),    byteBag(),    byteStack());
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.CHAR,    charList(),    charSet(),    charBag(),    charStack());
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.DOUBLE,  doubleList(),  doubleSet(),  doubleBag(),  doubleStack());
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.FLOAT,   floatList(),   floatSet(),   floatBag(),   floatStack());
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.INT,     intList(),     intSet(),     intBag(),     intStack());
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.LONG,    longList(),    longSet(),    longBag(),    longStack());
+    FACTORIES_BY_TYPE.withKeyMultiValues(PrimitiveType.SHORT,   shortList(),   shortSet(),   shortBag(),   shortStack());
+  }
+
+  private ImmutableSet<PrimitiveType> types;
+
+  @Override
+  public void accept(PrimitiveIterableParameterizedTest annotation) {
+    this.types = Sets.immutable.of(annotation.type());
+  }
+
+  @Override
+  public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+    RichIterable<PrimitiveIterableAssertFactory<?>> primitiveIterableAssertFactories;
+    if (types.isEmpty()) {
+      primitiveIterableAssertFactories = FACTORIES_BY_TYPE.valuesView();
+    } else {
+      primitiveIterableAssertFactories = types.flatCollect(FACTORIES_BY_TYPE::get);
+    }
+    return primitiveIterableAssertFactories.collect(Arguments::arguments).toList().stream();
+  }
+
+  static PrimitiveIterableAssertFactory<BooleanIterableAssert> booleanList() {
+    return new PrimitiveIterableAssertFactory<>("Boolean List",
+      elements -> new BooleanIterableAssert(toBooleanList(elements)),
+      size -> new BooleanIterableAssert(BooleanLists.immutable.of(new boolean[size])),
+      () -> new BooleanIterableAssert(BooleanLists.immutable.empty()),
+      () -> new BooleanIterableAssert(null),
+      (softAssertions, size) -> softAssertions.assertThat(BooleanLists.immutable.of(new boolean[size])));
+  }
+
+  private static MutableBooleanList toBooleanList(Object[] elements) {
+    return ArrayAdapter.adapt(elements).collectBoolean(Boolean.class::cast);
+  }
+
+  static PrimitiveIterableAssertFactory<BooleanIterableAssert> booleanSet() {
+    return new PrimitiveIterableAssertFactory<>("Boolean Set",
+      elements -> new BooleanIterableAssert(toBooleanSet(elements)),
+      size -> new BooleanIterableAssert(BooleanSets.immutable.of(distinctBooleans(size))),
+      () -> new BooleanIterableAssert(BooleanSets.immutable.empty()),
+      () -> new BooleanIterableAssert(null),
+      (softAssertions, size) -> softAssertions.assertThat(BooleanSets.immutable.of(distinctBooleans(size))));
+  }
+
+  private static MutableBooleanSet toBooleanSet(Object[] elements) {
+    return toBooleanList(elements).toSet();
+  }
+
+  static PrimitiveIterableAssertFactory<BooleanIterableAssert> booleanBag() {
+    return new PrimitiveIterableAssertFactory<>("Boolean Bag",
+      elements -> new BooleanIterableAssert(toBooleanBag(elements)),
+      n -> new BooleanIterableAssert(BooleanBags.immutable.of(new boolean[n])),
+      () -> new BooleanIterableAssert(BooleanBags.immutable.empty()),
+      () -> new BooleanIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(BooleanBags.immutable.of(new boolean[n])));
+  }
+
+  private static MutableBooleanBag toBooleanBag(Object[] elements) {
+    return toBooleanList(elements).toBag();
+  }
+
+  static PrimitiveIterableAssertFactory<BooleanIterableAssert> booleanStack() {
+    return new PrimitiveIterableAssertFactory<>("Boolean Stack",
+      elements -> new BooleanIterableAssert(toBooleanStack(elements)),
+      n -> new BooleanIterableAssert(BooleanStacks.immutable.of(new boolean[n])),
+      () -> new BooleanIterableAssert(BooleanStacks.immutable.empty()),
+      () -> new BooleanIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(BooleanStacks.immutable.of(new boolean[n])));
+  }
+
+  private static MutableBooleanStack toBooleanStack(Object[] elements) {
+    return toBooleanList(elements).toStack();
+  }
+
+  private static boolean[] distinctBooleans(int n) {
+    boolean[] arr = new boolean[n];
+    for (int i = 0; i < n; i++) {
+      arr[i] = (i % 2 != 0);
+    }
+    return arr;
+  }
+
+  static PrimitiveIterableAssertFactory<ByteIterableAssert> byteList() {
+    return new PrimitiveIterableAssertFactory<>("Byte List",
+      objects -> new  ByteIterableAssert(ArrayAdapter.adapt(objects).collectByte(Byte.class::cast)),
+      n -> new ByteIterableAssert(ByteLists.immutable.of(new byte[n])),
+      () -> new ByteIterableAssert(ByteLists.immutable.empty()),
+      () -> new ByteIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ByteLists.immutable.of(new byte[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<ByteIterableAssert> byteSet() {
+    return new PrimitiveIterableAssertFactory<>("Byte Set",
+      objects -> new  ByteIterableAssert(ArrayAdapter.adapt(objects).collectByte(Byte.class::cast).toSet()),
+      n -> new ByteIterableAssert(ByteSets.immutable.of(distinctBytes(n))),
+      () -> new ByteIterableAssert(ByteSets.immutable.empty()),
+      () -> new ByteIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ByteSets.immutable.of(distinctBytes(n))));
+  }
+
+  static PrimitiveIterableAssertFactory<ByteIterableAssert> byteBag() {
+    return new PrimitiveIterableAssertFactory<>("Byte Bag",
+      objects -> new  ByteIterableAssert(ArrayAdapter.adapt(objects).collectByte(Byte.class::cast).toBag()),
+      n -> new ByteIterableAssert(ByteBags.immutable.of(new byte[n])),
+      () -> new ByteIterableAssert(ByteBags.immutable.empty()),
+      () -> new ByteIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ByteBags.immutable.of(new byte[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<ByteIterableAssert> byteStack() {
+    return new PrimitiveIterableAssertFactory<>("Byte Stack",
+      objects -> new  ByteIterableAssert(ArrayAdapter.adapt(objects).collectByte(Byte.class::cast).toStack()),
+      n -> new ByteIterableAssert(ByteStacks.immutable.of(new byte[n])),
+      () -> new ByteIterableAssert(ByteStacks.immutable.empty()),
+      () -> new ByteIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ByteStacks.immutable.of(new byte[n])));
+  }
+
+  private static byte[] distinctBytes(int n) {
+    byte[] arr = new byte[n];
+    for (int i = 0; i < n; i++) arr[i] = (byte) i;
+    return arr;
+  }
+
+  static PrimitiveIterableAssertFactory<CharIterableAssert> charList() {
+    return new PrimitiveIterableAssertFactory<>("Char List",
+      objects -> new  CharIterableAssert(ArrayAdapter.adapt(objects).collectChar(Character.class::cast)),
+      n -> new CharIterableAssert(CharLists.immutable.of(new char[n])),
+      () -> new CharIterableAssert(CharLists.immutable.empty()),
+      () -> new CharIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(CharLists.immutable.of(new char[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<CharIterableAssert> charSet() {
+    return new PrimitiveIterableAssertFactory<>("Char Set",
+      objects -> new  CharIterableAssert(ArrayAdapter.adapt(objects).collectChar(Character.class::cast).toSet()),
+      n -> new CharIterableAssert(CharSets.immutable.of(distinctChars(n))),
+      () -> new CharIterableAssert(CharSets.immutable.empty()),
+      () -> new CharIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(CharSets.immutable.of(distinctChars(n))));
+  }
+
+  static PrimitiveIterableAssertFactory<CharIterableAssert> charBag() {
+    return new PrimitiveIterableAssertFactory<>("Char Bag",
+      objects -> new  CharIterableAssert(ArrayAdapter.adapt(objects).collectChar(Character.class::cast).toBag()),
+      n -> new CharIterableAssert(CharBags.immutable.of(new char[n])),
+      () -> new CharIterableAssert(CharBags.immutable.empty()),
+      () -> new CharIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(CharBags.immutable.of(new char[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<CharIterableAssert> charStack() {
+    return new PrimitiveIterableAssertFactory<>("Char Stack",
+      objects -> new  CharIterableAssert(ArrayAdapter.adapt(objects).collectChar(Character.class::cast).toStack()),
+      n -> new CharIterableAssert(CharStacks.immutable.of(new char[n])),
+      () -> new CharIterableAssert(CharStacks.immutable.empty()),
+      () -> new CharIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(CharStacks.immutable.of(new char[n])));
+  }
+
+  private static char[] distinctChars(int n) {
+    char[] arr = new char[n];
+    for (int i = 0; i < n; i++) arr[i] = (char) ('a' + i);
+    return arr;
+  }
+
+  static PrimitiveIterableAssertFactory<DoubleIterableAssert> doubleList() {
+    return new PrimitiveIterableAssertFactory<>("Double List",
+      objects -> new  DoubleIterableAssert(ArrayAdapter.adapt(objects).collectDouble(Double.class::cast)),
+      n -> new DoubleIterableAssert(DoubleLists.immutable.of(new double[n])),
+      () -> new DoubleIterableAssert(DoubleLists.immutable.empty()),
+      () -> new DoubleIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(DoubleLists.immutable.of(new double[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<DoubleIterableAssert> doubleSet() {
+    return new PrimitiveIterableAssertFactory<>("Double Set",
+      objects -> new  DoubleIterableAssert(ArrayAdapter.adapt(objects).collectDouble(Double.class::cast).toSet()),
+      n -> new DoubleIterableAssert(DoubleSets.immutable.of(distinctDoubles(n))),
+      () -> new DoubleIterableAssert(DoubleSets.immutable.empty()),
+      () -> new DoubleIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(DoubleSets.immutable.of(distinctDoubles(n))));
+  }
+
+  static PrimitiveIterableAssertFactory<DoubleIterableAssert> doubleBag() {
+    return new PrimitiveIterableAssertFactory<>("Double Bag",
+      objects -> new  DoubleIterableAssert(ArrayAdapter.adapt(objects).collectDouble(Double.class::cast).toBag()),
+      n -> new DoubleIterableAssert(DoubleBags.immutable.of(new double[n])),
+      () -> new DoubleIterableAssert(DoubleBags.immutable.empty()),
+      () -> new DoubleIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(DoubleBags.immutable.of(new double[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<DoubleIterableAssert> doubleStack() {
+    return new PrimitiveIterableAssertFactory<>("Double Stack",
+      objects -> new  DoubleIterableAssert(ArrayAdapter.adapt(objects).collectDouble(Double.class::cast).toStack()),
+      n -> new DoubleIterableAssert(DoubleStacks.immutable.of(new double[n])),
+      () -> new DoubleIterableAssert(DoubleStacks.immutable.empty()),
+      () -> new DoubleIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(DoubleStacks.immutable.of(new double[n])));
+  }
+
+  private static double[] distinctDoubles(int n) {
+    double[] arr = new double[n];
+    for (int i = 0; i < n; i++) arr[i] = i;
+    return arr;
+  }
+
+  static PrimitiveIterableAssertFactory<FloatIterableAssert> floatList() {
+    return new PrimitiveIterableAssertFactory<>("Float List",
+      objects -> new  FloatIterableAssert(ArrayAdapter.adapt(objects).collectFloat(Float.class::cast)),
+      n -> new FloatIterableAssert(FloatLists.immutable.of(new float[n])),
+      () -> new FloatIterableAssert(FloatLists.immutable.empty()),
+      () -> new FloatIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(FloatLists.immutable.of(new float[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<FloatIterableAssert> floatSet() {
+    return new PrimitiveIterableAssertFactory<>("Float Set",
+      objects -> new  FloatIterableAssert(ArrayAdapter.adapt(objects).collectFloat(Float.class::cast).toSet()),
+      n -> new FloatIterableAssert(FloatSets.immutable.of(distinctFloats(n))),
+      () -> new FloatIterableAssert(FloatSets.immutable.empty()),
+      () -> new FloatIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(FloatSets.immutable.of(distinctFloats(n))));
+  }
+
+  static PrimitiveIterableAssertFactory<FloatIterableAssert> floatBag() {
+    return new PrimitiveIterableAssertFactory<>("Float Bag",
+      objects -> new  FloatIterableAssert(ArrayAdapter.adapt(objects).collectFloat(Float.class::cast).toBag()),
+      n -> new FloatIterableAssert(FloatBags.immutable.of(new float[n])),
+      () -> new FloatIterableAssert(FloatBags.immutable.empty()),
+      () -> new FloatIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(FloatBags.immutable.of(new float[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<FloatIterableAssert> floatStack() {
+    return new PrimitiveIterableAssertFactory<>("Float Stack",
+      objects -> new  FloatIterableAssert(ArrayAdapter.adapt(objects).collectFloat(Float.class::cast).toStack()),
+      n -> new FloatIterableAssert(FloatStacks.immutable.of(new float[n])),
+      () -> new FloatIterableAssert(FloatStacks.immutable.empty()),
+      () -> new FloatIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(FloatStacks.immutable.of(new float[n])));
+  }
+
+  private static float[] distinctFloats(int n) {
+    float[] arr = new float[n];
+    for (int i = 0; i < n; i++) arr[i] = i;
+    return arr;
+  }
+
+  static PrimitiveIterableAssertFactory<IntIterableAssert> intList() {
+    return new PrimitiveIterableAssertFactory<>("Int List",
+      objects -> new  IntIterableAssert(ArrayAdapter.adapt(objects).collectInt(Integer.class::cast)),
+      n -> new IntIterableAssert(IntLists.immutable.of(new int[n])),
+      () -> new IntIterableAssert(IntLists.immutable.empty()),
+      () -> new IntIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(IntLists.immutable.of(new int[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<IntIterableAssert> intSet() {
+    return new PrimitiveIterableAssertFactory<>("Int Set",
+      objects -> new  IntIterableAssert(ArrayAdapter.adapt(objects).collectInt(Integer.class::cast).toSet()),
+      n -> new IntIterableAssert(IntSets.immutable.of(distinctInts(n))),
+      () -> new IntIterableAssert(IntSets.immutable.empty()),
+      () -> new IntIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(IntSets.immutable.of(distinctInts(n))));
+  }
+
+  static PrimitiveIterableAssertFactory<IntIterableAssert> intBag() {
+    return new PrimitiveIterableAssertFactory<>("Int Bag",
+      objects -> new  IntIterableAssert(ArrayAdapter.adapt(objects).collectInt(Integer.class::cast).toBag()),
+      n -> new IntIterableAssert(IntBags.immutable.of(new int[n])),
+      () -> new IntIterableAssert(IntBags.immutable.empty()),
+      () -> new IntIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(IntBags.immutable.of(new int[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<IntIterableAssert> intStack() {
+    return new PrimitiveIterableAssertFactory<>("Int Stack",
+      objects -> new  IntIterableAssert(ArrayAdapter.adapt(objects).collectInt(Integer.class::cast).toStack()),
+      n -> new IntIterableAssert(IntStacks.immutable.of(new int[n])),
+      () -> new IntIterableAssert(IntStacks.immutable.empty()),
+      () -> new IntIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(IntStacks.immutable.of(new int[n])));
+  }
+
+  private static int[] distinctInts(int n) {
+    int[] arr = new int[n];
+    for (int i = 0; i < n; i++) arr[i] = i;
+    return arr;
+  }
+
+  static PrimitiveIterableAssertFactory<LongIterableAssert> longList() {
+    return new PrimitiveIterableAssertFactory<>("Long List",
+      objects -> new  LongIterableAssert(ArrayAdapter.adapt(objects).collectLong(Long.class::cast)),
+      n -> new LongIterableAssert(LongLists.immutable.of(new long[n])),
+      () -> new LongIterableAssert(LongLists.immutable.empty()),
+      () -> new LongIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(LongLists.immutable.of(new long[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<LongIterableAssert> longSet() {
+    return new PrimitiveIterableAssertFactory<>("Long Set",
+      objects -> new  LongIterableAssert(ArrayAdapter.adapt(objects).collectLong(Long.class::cast).toSet()),
+      n -> new LongIterableAssert(LongSets.immutable.of(distinctLongs(n))),
+      () -> new LongIterableAssert(LongSets.immutable.empty()),
+      () -> new LongIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(LongSets.immutable.of(distinctLongs(n))));
+  }
+
+  static PrimitiveIterableAssertFactory<LongIterableAssert> longBag() {
+    return new PrimitiveIterableAssertFactory<>("Long Bag",
+      objects -> new  LongIterableAssert(ArrayAdapter.adapt(objects).collectLong(Long.class::cast).toBag()),
+      n -> new LongIterableAssert(LongBags.immutable.of(new long[n])),
+      () -> new LongIterableAssert(LongBags.immutable.empty()),
+      () -> new LongIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(LongBags.immutable.of(new long[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<LongIterableAssert> longStack() {
+    return new PrimitiveIterableAssertFactory<>("Long Stack",
+      objects -> new  LongIterableAssert(ArrayAdapter.adapt(objects).collectLong(Long.class::cast).toStack()),
+      n -> new LongIterableAssert(LongStacks.immutable.of(new long[n])),
+      () -> new LongIterableAssert(LongStacks.immutable.empty()),
+      () -> new LongIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(LongStacks.immutable.of(new long[n])));
+  }
+
+  private static long[] distinctLongs(int n) {
+    long[] arr = new long[n];
+    for (int i = 0; i < n; i++) arr[i] = i;
+    return arr;
+  }
+
+  static PrimitiveIterableAssertFactory<ShortIterableAssert> shortList() {
+    return new PrimitiveIterableAssertFactory<>("Short List",
+      objects -> new  ShortIterableAssert(ArrayAdapter.adapt(objects).collectShort(Short.class::cast)),
+      n -> new ShortIterableAssert(ShortLists.immutable.of(new short[n])),
+      () -> new ShortIterableAssert(ShortLists.immutable.empty()),
+      () -> new ShortIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ShortLists.immutable.of(new short[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<ShortIterableAssert> shortSet() {
+    return new PrimitiveIterableAssertFactory<>("Short Set",
+      objects -> new  ShortIterableAssert(ArrayAdapter.adapt(objects).collectShort(Short.class::cast).toSet()),
+      n -> new ShortIterableAssert(ShortSets.immutable.of(distinctShorts(n))),
+      () -> new ShortIterableAssert(ShortSets.immutable.empty()),
+      () -> new ShortIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ShortSets.immutable.of(distinctShorts(n))));
+  }
+
+  static PrimitiveIterableAssertFactory<ShortIterableAssert> shortBag() {
+    return new PrimitiveIterableAssertFactory<>("Short Bag",
+      objects -> new  ShortIterableAssert(ArrayAdapter.adapt(objects).collectShort(Short.class::cast).toBag()),
+      n -> new ShortIterableAssert(ShortBags.immutable.of(new short[n])),
+      () -> new ShortIterableAssert(ShortBags.immutable.empty()),
+      () -> new ShortIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ShortBags.immutable.of(new short[n])));
+  }
+
+  static PrimitiveIterableAssertFactory<ShortIterableAssert> shortStack() {
+    return new PrimitiveIterableAssertFactory<>("Short Stack",
+      objects -> new  ShortIterableAssert(ArrayAdapter.adapt(objects).collectShort(Short.class::cast).toStack()),
+      n -> new ShortIterableAssert(ShortStacks.immutable.of(new short[n])),
+      () -> new ShortIterableAssert(ShortStacks.immutable.empty()),
+      () -> new ShortIterableAssert(null),
+      (softAssertions, n) -> softAssertions.assertThat(ShortStacks.immutable.of(new short[n])));
+  }
+
+  private static short[] distinctShorts(int n) {
+    short[] arr = new short[n];
+    for (int i = 0; i < n; i++) arr[i] = (short) i;
+    return arr;
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssertFactory.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssertFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+
+import org.assertj.eclipse.collections.api.AbstractPrimitiveIterableAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+class PrimitiveIterableAssertFactory<T extends AbstractPrimitiveIterableAssert<?, ?>> {
+  private final String name;
+  private final Function<Object[], T> fromElements;
+  private final IntFunction<T> fromSize;
+  private final Supplier<T> fromEmpty;
+  private final Supplier<T> fromNull;
+  private final BiFunction<SoftAssertions, Integer, T> softlyFromSize;
+
+  PrimitiveIterableAssertFactory(
+    String name,
+    Function<Object[], T> fromElements,
+    IntFunction<T> fromSize,
+    Supplier<T> fromEmpty,
+    Supplier<T> fromNull,
+    BiFunction<SoftAssertions, Integer, T> softlyFromSize) {
+    this.name = name;
+    this.fromElements = fromElements;
+    this.fromSize = fromSize;
+    this.fromEmpty = fromEmpty;
+    this.fromNull = fromNull;
+    this.softlyFromSize = softlyFromSize;
+  }
+
+  public T fromElements(Object... elements) {
+    return fromElements.apply(elements);
+  }
+
+  public T fromSize(int size) {
+    return fromSize.apply(size);
+  }
+
+  public T fromEmpty() {
+    return fromEmpty.get();
+  }
+
+  public T fromNull() {
+    return fromNull.get();
+  }
+
+  public T softlyFromSize(SoftAssertions softAssertions, int size) {
+    return softlyFromSize.apply(softAssertions, size);
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_Contains_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_Contains_Test.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BooleanIterableAssert;
+import org.assertj.eclipse.collections.api.ByteIterableAssert;
+import org.assertj.eclipse.collections.api.CharIterableAssert;
+import org.assertj.eclipse.collections.api.DoubleIterableAssert;
+import org.assertj.eclipse.collections.api.FloatIterableAssert;
+import org.assertj.eclipse.collections.api.IntIterableAssert;
+import org.assertj.eclipse.collections.api.LongIterableAssert;
+import org.assertj.eclipse.collections.api.ShortIterableAssert;
+import org.junit.jupiter.api.Nested;
+
+class PrimitiveIterableAssert_Contains_Test {
+
+  @Nested
+  class BooleanTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void passes(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(true, false, false).contains(true));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void fails(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(false, false, false).contains(true))
+        .withMessageContaining("to contain");
+    }
+  }
+
+  @Nested
+  class ByteTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void passes(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((byte) 1, (byte) 2, (byte) 3).contains((byte) 2));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void fails(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((byte) 1).contains((byte) 99))
+        .withMessageContaining("to contain");
+    }
+  }
+
+  @Nested
+  class CharTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void passes(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements('a', 'b', 'c').contains('b'));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void fails(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements('a').contains('z'))
+        .withMessageContaining("to contain");
+    }
+  }
+
+  @Nested
+  class DoubleTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void passes(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1.0, 2.0, 3.0).contains(2.0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void fails(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1.0).contains(99.0))
+        .withMessageContaining("to contain");
+    }
+  }
+
+  @Nested
+  class FloatTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void passes(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1.0f, 2.0f, 3.0f).contains(2.0f));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void fails(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1.0f).contains(99.0f))
+        .withMessageContaining("to contain");
+    }
+  }
+
+  @Nested
+  class IntTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void passes(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1, 2, 3).contains(2));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void fails(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1).contains(99))
+        .withMessageContaining("to contain");
+    }
+  }
+
+  @Nested
+  class LongTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void passes(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1L, 2L, 3L).contains(2L));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void fails(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1L).contains(99L))
+        .withMessageContaining("to contain");
+    }
+  }
+
+  @Nested
+  class ShortTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void passes(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((short) 1, (short) 2, (short) 3).contains((short) 2));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void fails(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((short) 1).contains((short) 99))
+        .withMessageContaining("to contain");
+    }
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableParameterizedTest.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableParameterizedTest.java
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Test module for AssertJ Eclipse Collections
- */
-open module org.assertj.eclipse.collections.test {
-  exports org.assertj.eclipse.collections.api.list;
-  exports org.assertj.eclipse.collections.api.multimap;
-  exports org.assertj.eclipse.collections.api.primitive;
-  exports org.assertj.eclipse.collections.api.richiterable;
-  exports org.assertj.eclipse.collections.api.stack;
+package org.assertj.eclipse.collections.api.primitive;
 
-  requires org.assertj.eclipse.collections;
-  requires org.assertj.core;
-  requires org.eclipse.collections.api;
-  requires org.eclipse.collections.impl;
-  requires org.junit.jupiter.api;
-  requires org.junit.jupiter.params;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@ParameterizedTest(name = "{0}")
+@ArgumentsSource(PrimitiveIterableArgumentsProvider.class)
+public @interface PrimitiveIterableParameterizedTest {
+
+  PrimitiveType[] type() default {};
 }

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveType.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveType.java
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Test module for AssertJ Eclipse Collections
- */
-open module org.assertj.eclipse.collections.test {
-  exports org.assertj.eclipse.collections.api.list;
-  exports org.assertj.eclipse.collections.api.multimap;
-  exports org.assertj.eclipse.collections.api.primitive;
-  exports org.assertj.eclipse.collections.api.richiterable;
-  exports org.assertj.eclipse.collections.api.stack;
+package org.assertj.eclipse.collections.api.primitive;
 
-  requires org.assertj.eclipse.collections;
-  requires org.assertj.core;
-  requires org.eclipse.collections.api;
-  requires org.eclipse.collections.impl;
-  requires org.junit.jupiter.api;
-  requires org.junit.jupiter.params;
+public enum PrimitiveType {
+  BOOLEAN,
+  BYTE,
+  CHAR,
+  DOUBLE,
+  FLOAT,
+  INT,
+  LONG,
+  SHORT
 }


### PR DESCRIPTION
This PR introduces the `AbstractPrimitiveIterableAssert` class and supporting implementation skeleton classes for the primitive collections. Eclipse Collections has a set of dedicated primitive collections that avoid boxing/unboxing of primitive types. Because of this, they can't share the same interfaces that the traditional collections use. This requires a whole new assertion hierarchy that is based on the base `PrimitiveIterable` interface.

I've started with implementing the size assertions in `AbstractPrimitiveIterableAssert` and the contains assertion in each of the eight primitive type concrete assertion classes. There isn't a common interface I can link the contains method with in each class so I've created a JUnit parametrized test harness that will exercise each of the primitive types collections. This ensures that the method is consistent across types.

I do expected this type hierarchy to change over time but I want to get the skeleton in place so I can iterate on it as more assertions are added.