### PR TITLE
Add distinct size assertions for BagAssert and allMatch for RichIterable

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -19,8 +19,9 @@
 module org.assertj.eclipse.collections {
   exports org.assertj.eclipse.collections.api;
   exports org.assertj.eclipse.collections.error;
+  exports org.assertj.eclipse.collections.util;
 
-  requires org.assertj.core;
-  requires org.eclipse.collections.api;
+  requires transitive org.assertj.core;
+  requires transitive org.eclipse.collections.api;
   requires org.eclipse.collections.impl;
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -15,6 +15,8 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldBeAnArray.shouldBeAnArray;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
@@ -26,8 +28,8 @@ import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHa
 import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
 import static org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo.shouldHaveSizeLessThanOrEqualTo;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
-import static org.assertj.core.util.IterableUtil.sizeOf;
 import static org.assertj.core.util.Preconditions.checkArgument;
+import static org.assertj.eclipse.collections.util.RichIterableUtil.sizeOf;
 
 import java.lang.reflect.Array;
 import java.util.Objects;
@@ -37,7 +39,9 @@ import java.util.function.Predicate;
 import org.assertj.core.annotation.CheckReturnValue;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.list.ImmutableList;
 
 /**
  * Base class for implementations of Eclipse Collections {@link RichIterable} assertions.
@@ -59,6 +63,29 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
 
   protected AbstractRichIterableAssert(ACTUAL actual, Class<?> selfType) {
     super(actual, selfType);
+  }
+
+  @Override
+  public SELF allMatch(Predicate<? super ELEMENT> predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  @Override
+  public SELF allMatch(Predicate<? super ELEMENT> predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(Predicate<? super ELEMENT> predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    ImmutableList<? extends ELEMENT> nonMatches = actual.reject(predicate::test).toImmutableList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   @Override
@@ -103,20 +130,16 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSameSizeAs(Iterable<?> other) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    final int otherSize;
-    if (other instanceof RichIterable<?> richIterable) {
-      otherSize = richIterable.size();
-    } else {
-      otherSize = sizeOf(other);
-    }
-
-    int actualSize = actual.size();
-    if (actualSize == otherSize) {
-      return myself;
-    }
-    throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+      int otherSize = sizeOf(other);
+      int actualSize = actual.size();
+      if (actualSize == otherSize) {
+        return;
+      }
+      throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+    });
   }
 
   /**
@@ -129,19 +152,21 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSameSizeAs(Object other) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    if (!(other != null && other.getClass().isArray())) {
-      throw assertionError(shouldBeAnArray(other));
-    }
+      if (!(other != null && other.getClass().isArray())) {
+        throw assertionError(shouldBeAnArray(other));
+      }
 
-    int otherSize = Array.getLength(other);
-    int actualSize = actual.size();
-    if (actualSize == otherSize) {
-      return myself;
-    }
+      int otherSize = Array.getLength(other);
+      int actualSize = actual.size();
+      if (actualSize == otherSize) {
+        return;
+      }
 
-    throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+      throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+    });
   }
 
   /**
@@ -164,14 +189,16 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSize(int expected) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    int actualSize = actual.size();
-    if (actualSize == expected) {
-      return myself;
-    }
+      int actualSize = actual.size();
+      if (actualSize == expected) {
+        return;
+      }
 
-    throw assertionError(shouldHaveSize(actual, actualSize, expected));
+      throw assertionError(shouldHaveSize(actual, actualSize, expected));
+    });
   }
 
   /**
@@ -193,20 +220,22 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSizeBetween(int lowerBoundary, int higherBoundary) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    if (!(higherBoundary >= lowerBoundary)) {
-      throw new IllegalArgumentException("The higher boundary <%s> must be greater than the lower boundary <%s>.".formatted(
-        higherBoundary,
-        lowerBoundary));
-    }
+      if (!(higherBoundary >= lowerBoundary)) {
+        throw new IllegalArgumentException("The higher boundary <%s> must be greater than the lower boundary <%s>.".formatted(
+          higherBoundary,
+          lowerBoundary));
+      }
 
-    int actualSize = actual.size();
-    if (actualSize >= lowerBoundary && actualSize <= higherBoundary) {
-      return myself;
-    }
+      int actualSize = actual.size();
+      if (actualSize >= lowerBoundary && actualSize <= higherBoundary) {
+        return;
+      }
 
-    throw assertionError(shouldHaveSizeBetween(actual, actualSize, lowerBoundary, higherBoundary));
+      throw assertionError(shouldHaveSizeBetween(actual, actualSize, lowerBoundary, higherBoundary));
+    });
   }
 
   /**
@@ -226,14 +255,16 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSizeGreaterThan(int boundary) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    int actualSize = actual.size();
-    if (actualSize > boundary) {
-      return myself;
-    }
+      int actualSize = actual.size();
+      if (actualSize > boundary) {
+        return;
+      }
 
-    throw assertionError(shouldHaveSizeGreaterThan(actual, actualSize, boundary));
+      throw assertionError(shouldHaveSizeGreaterThan(actual, actualSize, boundary));
+    });
   }
 
   /**
@@ -255,14 +286,16 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSizeGreaterThanOrEqualTo(int boundary) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    int actualSize = actual.size();
-    if (actualSize >= boundary) {
-      return myself;
-    }
+      int actualSize = actual.size();
+      if (actualSize >= boundary) {
+        return;
+      }
 
-    throw assertionError(shouldHaveSizeGreaterThanOrEqualTo(actual, actualSize, boundary));
+      throw assertionError(shouldHaveSizeGreaterThanOrEqualTo(actual, actualSize, boundary));
+    });
   }
 
   /**
@@ -283,14 +316,16 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSizeLessThan(int boundary) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    int actualSize = actual.size();
-    if (actualSize < boundary) {
-      return myself;
-    }
+      int actualSize = actual.size();
+      if (actualSize < boundary) {
+        return;
+      }
 
-    throw assertionError(shouldHaveSizeLessThan(actual, actualSize, boundary));
+      throw assertionError(shouldHaveSizeLessThan(actual, actualSize, boundary));
+    });
   }
 
   /**
@@ -312,14 +347,16 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF hasSizeLessThanOrEqualTo(int boundary) {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    int actualSize = actual.size();
-    if (actualSize <= boundary) {
-      return myself;
-    }
+      int actualSize = actual.size();
+      if (actualSize <= boundary) {
+        return;
+      }
 
-    throw assertionError(shouldHaveSizeLessThanOrEqualTo(actual, actualSize, boundary));
+      throw assertionError(shouldHaveSizeLessThanOrEqualTo(actual, actualSize, boundary));
+    });
   }
 
   /**
@@ -329,13 +366,15 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public void isEmpty() {
-    isNotNull();
+    executeAssertion(() -> {
+      isNotNull();
 
-    if (actual.isEmpty()) {
-      return;
-    }
+      if (actual.isEmpty()) {
+        return;
+      }
 
-    throw assertionError(shouldBeEmpty(actual));
+      throw assertionError(shouldBeEmpty(actual));
+    });
   }
 
   /**
@@ -346,13 +385,15 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public SELF isNotEmpty() {
-    isNotNull();
+    return executeAssertion(() -> {
+      isNotNull();
 
-    if (actual.notEmpty()) {
-      return myself;
-    }
+      if (actual.notEmpty()) {
+        return;
+      }
 
-    throw assertionError(shouldNotBeEmpty());
+      throw assertionError(shouldNotBeEmpty());
+    });
   }
 
   /**
@@ -362,11 +403,13 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
    */
   @Override
   public void isNullOrEmpty() {
-    if (actual == null || actual.isEmpty()) {
-      return;
-    }
+    executeAssertion(() -> {
+      if (actual == null || actual.isEmpty()) {
+        return;
+      }
 
-    throw assertionError(shouldBeNullOrEmpty(actual));
+      throw assertionError(shouldBeNullOrEmpty(actual));
+    });
   }
 
   /**

--- a/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/Assertions.java
@@ -23,6 +23,7 @@ import org.eclipse.collections.api.DoubleIterable;
 import org.eclipse.collections.api.FloatIterable;
 import org.eclipse.collections.api.IntIterable;
 import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.list.ListIterable;
@@ -50,7 +51,7 @@ public class Assertions {
    * @param <T> The type of the elements in the bag
    */
   @CheckReturnValue
-  public static <T> BagAssert<T> assertThat(Bag<T> actual) {
+  public static <T> BagAssert<T> assertThat(Bag<? extends T> actual) {
     return new BagAssert<>(actual);
   }
 
@@ -128,7 +129,7 @@ public class Assertions {
    * @param <T> The type of the elements in the list
    */
   @CheckReturnValue
-  public static <T> ListIterableAssert<T> assertThat(ListIterable<T> actual) {
+  public static <T> ListIterableAssert<T> assertThat(ListIterable<? extends T> actual) {
     return new ListIterableAssert<>(actual);
   }
 
@@ -157,6 +158,18 @@ public class Assertions {
   }
 
   /**
+   * Creates a new instance of {@link RichIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @param <T> The type of elements in the RichIterable
+   */
+  @CheckReturnValue
+  public static <T> RichIterableAssert<T> assertThat(RichIterable<? extends T> actual) {
+    return new RichIterableAssert<>(actual);
+  }
+
+  /**
    * Creates a new instance of {@link SetIterableAssert}.
    *
    * @param actual the actual value.
@@ -164,7 +177,7 @@ public class Assertions {
    * @param <T> The type of the elements in the set
    */
   @CheckReturnValue
-  public static <T> SetIterableAssert<T> assertThat(SetIterable<T> actual) {
+  public static <T> SetIterableAssert<T> assertThat(SetIterable<? extends T> actual) {
     return new SetIterableAssert<>(actual);
   }
 
@@ -187,7 +200,7 @@ public class Assertions {
    * @param <T> The type of the elements in the stack
    */
   @CheckReturnValue
-  public static <T> StackIterableAssert<T> assertThat(StackIterable<T> actual) {
+  public static <T> StackIterableAssert<T> assertThat(StackIterable<? extends T> actual) {
     return new StackIterableAssert<>(actual);
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BDDAssertions.java
@@ -23,6 +23,7 @@ import org.eclipse.collections.api.DoubleIterable;
 import org.eclipse.collections.api.FloatIterable;
 import org.eclipse.collections.api.IntIterable;
 import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.list.ListIterable;
@@ -50,7 +51,7 @@ public class BDDAssertions extends Assertions {
    * @param <T> The type of the elements in the bag
    */
   @CheckReturnValue
-  public static <T> BagAssert<T> then(Bag<T> actual) {
+  public static <T> BagAssert<T> then(Bag<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -128,7 +129,7 @@ public class BDDAssertions extends Assertions {
    * @param <T> The type of the elements in the list
    */
   @CheckReturnValue
-  public static <T> ListIterableAssert<T> then(ListIterable<T> actual) {
+  public static <T> ListIterableAssert<T> then(ListIterable<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -157,6 +158,18 @@ public class BDDAssertions extends Assertions {
   }
 
   /**
+   * Creates a new instance of {@link RichIterableAssert}.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   * @param <T> The type of the elements in the iterable
+   */
+  @CheckReturnValue
+  public static <T> RichIterableAssert<T> then(RichIterable<? extends T> actual) {
+    return assertThat(actual);
+  }
+
+  /**
    * Creates a new instance of {@link SetIterableAssert}.
    *
    * @param actual the actual value.
@@ -164,7 +177,7 @@ public class BDDAssertions extends Assertions {
    * @param <T> The type of the elements in the set
    */
   @CheckReturnValue
-  public static <T> SetIterableAssert<T> then(SetIterable<T> actual) {
+  public static <T> SetIterableAssert<T> then(SetIterable<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -187,7 +200,7 @@ public class BDDAssertions extends Assertions {
    * @param <T> The type of the elements in the stack
    */
   @CheckReturnValue
-  public static <T> StackIterableAssert<T> then(StackIterable<T> actual) {
+  public static <T> StackIterableAssert<T> then(StackIterable<? extends T> actual) {
     return assertThat(actual);
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/BagAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BagAssert.java
@@ -15,6 +15,13 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static org.assertj.eclipse.collections.error.ShouldHaveDistinctSize.shouldHaveDistinctSize;
+import static org.assertj.eclipse.collections.error.ShouldHaveDistinctSizeBetween.shouldHaveDistinctSizeBetween;
+import static org.assertj.eclipse.collections.error.ShouldHaveDistinctSizeGreaterThan.shouldHaveDistinctSizeGreaterThan;
+import static org.assertj.eclipse.collections.error.ShouldHaveDistinctSizeGreaterThanOrEqualTo.shouldHaveDistinctSizeGreaterThanOrEqualTo;
+import static org.assertj.eclipse.collections.error.ShouldHaveDistinctSizeLessThan.shouldHaveDistinctSizeLessThan;
+import static org.assertj.eclipse.collections.error.ShouldHaveDistinctSizeLessThanOrEqualTo.shouldHaveDistinctSizeLessThanOrEqualTo;
+
 import org.assertj.core.api.ObjectAssert;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.bag.ImmutableBag;
@@ -28,6 +35,90 @@ import org.eclipse.collections.api.factory.Bags;
 public class BagAssert<ELEMENT> extends AbstractRichIterableAssert<BagAssert<ELEMENT>, Bag<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> {
   public BagAssert(Bag<? extends ELEMENT> elements) {
     super(elements, BagAssert.class);
+  }
+
+  public BagAssert<ELEMENT> hasDistinctSize(int expected) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualDistinctSize = actual.sizeDistinct();
+      if (actualDistinctSize == expected) {
+        return;
+      }
+
+      throw assertionError(shouldHaveDistinctSize(actual, actualDistinctSize, expected));
+    });
+  }
+
+  public BagAssert<ELEMENT> hasDistinctSizeBetween(int lowerBoundary, int higherBoundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      if (!(higherBoundary >= lowerBoundary)) {
+        throw new IllegalArgumentException("The higher boundary <%s> must be greater than the lower boundary <%s>.".formatted(
+          higherBoundary,
+          lowerBoundary));
+      }
+
+      int actualSize = actual.sizeDistinct();
+      if (actualSize >= lowerBoundary && actualSize <= higherBoundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveDistinctSizeBetween(actual, actualSize, lowerBoundary, higherBoundary));
+    });
+  }
+
+  public BagAssert<ELEMENT> hasDistinctSizeGreaterThan(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualDistinctSize = actual.sizeDistinct();
+      if (actualDistinctSize > boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveDistinctSizeGreaterThan(actual, actualDistinctSize, boundary));
+    });
+  }
+
+  public BagAssert<ELEMENT> hasDistinctSizeGreaterThanOrEqualTo(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualDistinctSize = actual.sizeDistinct();
+      if (actualDistinctSize >= boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveDistinctSizeGreaterThanOrEqualTo(actual, actualDistinctSize, boundary));
+    });
+  }
+
+  public BagAssert<ELEMENT> hasDistinctSizeLessThan(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualDistinctSize = actual.sizeDistinct();
+      if (actualDistinctSize < boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveDistinctSizeLessThan(actual, actualDistinctSize, boundary));
+    });
+  }
+
+  public BagAssert<ELEMENT> hasDistinctSizeLessThanOrEqualTo(int boundary) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualDistinctSize = actual.sizeDistinct();
+      if (actualDistinctSize <= boundary) {
+        return;
+      }
+
+      throw assertionError(shouldHaveDistinctSizeLessThanOrEqualTo(actual, actualDistinctSize, boundary));
+    });
   }
 
   @Override

--- a/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/EclipseCollectionsSoftAssertionsProvider.java
@@ -24,6 +24,7 @@ import org.eclipse.collections.api.DoubleIterable;
 import org.eclipse.collections.api.FloatIterable;
 import org.eclipse.collections.api.IntIterable;
 import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.list.ListIterable;
@@ -147,6 +148,18 @@ public interface EclipseCollectionsSoftAssertionsProvider extends SoftAssertions
    */
   @CheckReturnValue
   default <KEY, VALUE> MultimapAssert<KEY, VALUE> assertThat(Multimap<KEY, VALUE> actual) {
+    return soft(Assertions.assertThat(actual));
+  }
+
+  /**
+   * Creates a new instance of {@link RichIterableAssert}.
+   *
+   * @param actual the actual value
+   * @return the created assertion object
+   * @param <T> The type of the elements in the RichIterable
+   */
+  @CheckReturnValue
+  default <T> RichIterableAssert<T> assertThat(RichIterable<? extends T> actual) {
     return soft(Assertions.assertThat(actual));
   }
 

--- a/src/main/java/org/assertj/eclipse/collections/api/RichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/RichIterableAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api;
+
+import org.assertj.core.api.ObjectAssert;
+import org.eclipse.collections.api.RichIterable;
+import org.eclipse.collections.api.factory.Lists;
+
+/**
+ * Assertion class for {@link RichIterable} instances.
+ *
+ * @param <T> the type of elements in the RichIterable being asserted
+ */
+public class RichIterableAssert<T> extends AbstractRichIterableAssert<RichIterableAssert<T>, RichIterable<? extends T>, T, ObjectAssert<T>> {
+  public RichIterableAssert(RichIterable<? extends T> actual) {
+    super(actual, RichIterableAssert.class);
+  }
+
+  @Override
+  protected ObjectAssert<T> toAssert(T value) {
+    return new ObjectAssert<>(value);
+  }
+
+  @Override
+  protected RichIterableAssert<T> newAbstractIterableAssert(Iterable<? extends T> iterable) {
+    return new RichIterableAssert<>(Lists.immutable.ofAll(iterable));
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/error/ShouldHaveDistinctSizeBetween.java
+++ b/src/main/java/org/assertj/eclipse/collections/error/ShouldHaveDistinctSizeBetween.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+public class ShouldHaveDistinctSizeBetween extends BasicErrorMessageFactory {
+  public static ErrorMessageFactory shouldHaveDistinctSizeBetween(Object actual, int actualSize, int lowerBoundary, int higherBoundary) {
+    return new ShouldHaveDistinctSizeBetween(actual, actualSize, lowerBoundary, higherBoundary);
+  }
+
+  private ShouldHaveDistinctSizeBetween(Object actual, int actualSize, int lowerBoundary, int higherBoundary) {
+    super("%nExpected distinct size to be between: %s and %s but was: %s in:%n%s".formatted(lowerBoundary, higherBoundary,
+        actualSize, "%s"),
+      actual);
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/error/ShouldHaveDistinctSizeLessThan.java
+++ b/src/main/java/org/assertj/eclipse/collections/error/ShouldHaveDistinctSizeLessThan.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+import static java.lang.String.format;
+
+public class ShouldHaveDistinctSizeLessThan extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldHaveDistinctSizeLessThan}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param actualSize the distinct size of {@code actual}.
+   * @param expectedMaxSize the expected distinct size.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveDistinctSizeLessThan(Object actual, int actualSize, int expectedMaxSize) {
+    return new ShouldHaveDistinctSizeLessThan(actual, actualSize, expectedMaxSize);
+  }
+
+  private ShouldHaveDistinctSizeLessThan(Object actual, int actualSize, int expectedSize) {
+    super(format("%n" +
+        "Expecting distinct size of:%n" +
+        "  %%s%n" +
+        "to be less than %s but was %s", expectedSize, actualSize),
+      actual);
+  }
+}

--- a/src/main/java/org/assertj/eclipse/collections/error/ShouldHaveDistinctSizeLessThanOrEqualTo.java
+++ b/src/main/java/org/assertj/eclipse/collections/error/ShouldHaveDistinctSizeLessThanOrEqualTo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.error;
+
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+import static java.lang.String.format;
+
+/**
+ * Creates an error message indicating that an assertion that verifies a maximum distinct size failed.
+ */
+public class ShouldHaveDistinctSizeLessThanOrEqualTo extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldHaveDistinctSizeLessThanOrEqualTo}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param actualSize the distinct size of {@code actual}.
+   * @param expectedMaxSize the expected distinct size.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveDistinctSizeLessThanOrEqualTo(Object actual, int actualSize, int expectedMaxSize) {
+    return new ShouldHaveDistinctSizeLessThanOrEqualTo(actual, actualSize, expectedMaxSize);
+  }
+
+  private ShouldHaveDistinctSizeLessThanOrEqualTo(Object actual, int actualSize, int expectedSize) {
+    super(format("%n" +
+        "Expecting distinct size of:%n" +
+        "  %%s%n" +
+        "to be less than or equal to %s but was %s", expectedSize, actualSize),
+      actual);
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeBetween_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeBetween_Test.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.bag;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BagAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+import org.junit.jupiter.api.Test;
+
+class BagAssert_HasDistinctSizeBetween_Test {
+  @Test
+  void passes() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeBetween(2, 5));
+  }
+
+  @Test
+  void passesLowerBound() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeBetween(3, 5));
+  }
+
+  @Test
+  void passesUpperBound() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeBetween(1, 3));
+  }
+
+  @Test
+  void failsBelowLowerBound() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeBetween(4, 6))
+      .withMessageContaining("Expected distinct size to be between: 4 and 6 but was: 3");
+  }
+
+  @Test
+  void failsAboveUpperBound() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeBetween(1, 2))
+      .withMessageContaining("Expected distinct size to be between: 1 and 2 but was: 3");
+  }
+
+  @Test
+  void failsEmpty() {
+    ImmutableBag<String> bag = Bags.immutable.empty();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeBetween(3, 5))
+      .withMessageContaining("Expected distinct size to be between: 3 and 5 but was: 0");
+  }
+
+  @Test
+  void failsInvalidBoundaries() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(IllegalArgumentException.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeBetween(5, 3))
+      .withMessageContaining("The higher boundary <3> must be greater than the lower boundary <5>.");
+  }
+
+  @Test
+  void failsNullInput() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(null).hasDistinctSizeBetween(3, 5))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @Test
+  void softAssertionPasses() {
+    ImmutableBag<String> bag = createBag();
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(bag).hasDistinctSizeBetween(2, 5));
+  }
+
+  private static ImmutableBag<String> createBag() {
+    return Bags.immutable.of("TOS", "TOS", "TNG", "DS9", "DS9");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeGreaterThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeGreaterThan_Test.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.bag;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BagAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+import org.junit.jupiter.api.Test;
+
+class BagAssert_HasDistinctSizeGreaterThan_Test {
+  @Test
+  void passes() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeGreaterThan(2));
+  }
+
+  @Test
+  void failsEmpty() {
+    ImmutableBag<String> bag = Bags.immutable.empty();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeGreaterThan(3))
+      .withMessageContaining(String.format("to be greater than %s but was 0", 3));
+  }
+
+  @Test
+  void failsEquals() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeGreaterThan(3))
+      .withMessageContaining(String.format("to be greater than %s but was 3", 3));
+  }
+
+  @Test
+  void failsLessThan() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeGreaterThan(5))
+      .withMessageContaining(String.format("to be greater than %s but was 3", 5));
+  }
+
+  @Test
+  void failsNullInput() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(null).hasDistinctSizeGreaterThan(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @Test
+  void softAssertionPasses() {
+    ImmutableBag<String> bag = createBag();
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(bag).hasDistinctSizeGreaterThan(2));
+  }
+
+  private static ImmutableBag<String> createBag() {
+    return Bags.immutable.of("TOS", "TOS", "TNG", "DS9", "DS9");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeLessThanOrEqualTo_Test.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.bag;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BagAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+import org.junit.jupiter.api.Test;
+
+class BagAssert_HasDistinctSizeLessThanOrEqualTo_Test {
+  @Test
+  void passes() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThanOrEqualTo(5));
+  }
+
+  @Test
+  void passesEquals() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThanOrEqualTo(3));
+  }
+
+  @Test
+  void passesEmpty() {
+    ImmutableBag<String> bag = Bags.immutable.empty();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThanOrEqualTo(3));
+  }
+
+  @Test
+  void failsGreaterThan() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThanOrEqualTo(2))
+      .withMessageContaining(String.format("to be less than or equal to %s but was 3", 2));
+  }
+
+  @Test
+  void failsNullInput() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(null).hasDistinctSizeLessThanOrEqualTo(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @Test
+  void softAssertionPasses() {
+    ImmutableBag<String> bag = createBag();
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(bag).hasDistinctSizeLessThanOrEqualTo(5));
+  }
+
+  private static ImmutableBag<String> createBag() {
+    return Bags.immutable.of("TOS", "TOS", "TNG", "DS9", "DS9");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeLessThan_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSizeLessThan_Test.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.bag;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BagAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+import org.junit.jupiter.api.Test;
+
+class BagAssert_HasDistinctSizeLessThan_Test {
+  @Test
+  void passes() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThan(5));
+  }
+
+  @Test
+  void passesEmpty() {
+    ImmutableBag<String> bag = Bags.immutable.empty();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThan(3));
+  }
+
+  @Test
+  void failsEquals() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThan(3))
+      .withMessageContaining(String.format("to be less than %s but was 3", 3));
+  }
+
+  @Test
+  void failsGreaterThan() {
+    ImmutableBag<String> bag = createBag();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSizeLessThan(2))
+      .withMessageContaining(String.format("to be less than %s but was 3", 2));
+  }
+
+  @Test
+  void failsNullInput() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(null).hasDistinctSizeLessThan(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @Test
+  void softAssertionPasses() {
+    ImmutableBag<String> bag = createBag();
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(bag).hasDistinctSizeLessThan(5));
+  }
+
+  private static ImmutableBag<String> createBag() {
+    return Bags.immutable.of("TOS", "TOS", "TNG", "DS9", "DS9");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSize_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/bag/BagAssert_HasDistinctSize_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.bag;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BagAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.eclipse.collections.api.bag.ImmutableBag;
+import org.eclipse.collections.api.factory.Bags;
+import org.junit.jupiter.api.Test;
+
+class BagAssert_HasDistinctSize_Test {
+  @Test
+  void passes() {
+    ImmutableBag<String> bag = createBag();
+    assertThatNoException().isThrownBy(() -> new BagAssert<>(bag).hasDistinctSize(3));
+  }
+
+  @Test
+  void failsEmpty() {
+    ImmutableBag<String> bag = Bags.immutable.empty();
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(bag).hasDistinctSize(3))
+      .withMessageContaining(String.format("Expected distinct size: %s but was: 0", 3));
+  }
+
+  @Test
+  void failsNullInput() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> new BagAssert<>(null).hasDistinctSize(3))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @Test
+  void softAssertionPasses() {
+    ImmutableBag<String> bag = createBag();
+    SoftAssertions.assertSoftly(softly -> softly.assertThat(bag).hasDistinctSize(3));
+  }
+
+  private static ImmutableBag<String> createBag() {
+    return Bags.immutable.of("TOS", "TOS", "TNG", "DS9", "DS9");
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_AllMatch_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_AllMatch_Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_AllMatch_Test {
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allMatch(s -> s.length() == 3));
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().allMatch(s -> s.length() == 3))
+      .withMessageContaining("Expecting actual not to be empty");
+  }
+
+  @RichIterableParameterizedTest
+  void fails(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allMatch(s -> !s.equals("DS9")))
+      .withMessageContaining("to match given predicate but this element did not:");
+  }
+
+  @RichIterableParameterizedTest
+  void passesWithDescription(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allMatch(s -> s.length() == 3, "has length 3"));
+  }
+
+  @RichIterableParameterizedTest
+  void failsWithDescription(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allMatch(s -> !s.equals("DS9"), "is not DS9"))
+      .withMessageContaining("to match 'is not DS9' predicate but this element did not:");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").allMatch(s -> s.length() == 3));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/RichIterableArgumentsProvider.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/RichIterableArgumentsProvider.java
@@ -21,8 +21,10 @@ import java.util.stream.Stream;
 
 import org.assertj.eclipse.collections.api.BagAssert;
 import org.assertj.eclipse.collections.api.ListIterableAssert;
+import org.assertj.eclipse.collections.api.RichIterableAssert;
 import org.assertj.eclipse.collections.api.SetIterableAssert;
 import org.assertj.eclipse.collections.api.StackIterableAssert;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Bags;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
@@ -36,10 +38,21 @@ class RichIterableArgumentsProvider implements ArgumentsProvider {
   @Override
   public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
     return Stream.of(
+      arguments(createRichIterableAssert()),
       arguments(createBagAssert()),
       arguments(createListIterableAssert()),
       arguments(createSetIterableAssert()),
       arguments(createStackIterableAssert())
+    );
+  }
+
+  private static RichIterableAssertFactory<Object> createRichIterableAssert() {
+    return new RichIterableAssertFactory<>(
+      "RichIterable",
+      elements -> new RichIterableAssert<>(Lists.immutable.of(elements)),
+      () -> new RichIterableAssert<>(Lists.immutable.empty()),
+      () -> new RichIterableAssert<>(null),
+      (softAssertions, elements) -> softAssertions.assertThat((RichIterable<Object>) Lists.immutable.of(elements))
     );
   }
 


### PR DESCRIPTION
I've started to dogfood the library by replacing the eclipse collections `Verify` assertions with AssertJ. This uncovered a bunch of miscellaneous changes that were needed:

- A `RichIterableAssert` to handle this type when anything more specific doesn't matter
- Better parameterized typing to match the core AssertJ code
- Updated soft assertion handling in 4.x
- Correct JPMS exports declarations for transitive dependencies.

I also had a bunch of the `BagAssert` distinct size assertions done as well as the allMatch method done in `AbstractRichIterableAssert`.