### PR TITLE
Add allMatch and allSatisfy methods and contains method for RichIterable

### DIFF
--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -41,6 +41,7 @@ import org.assertj.core.annotation.CheckReturnValue;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.presentation.PredicateDescription;
+import org.eclipse.collections.api.PrimitiveIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
@@ -182,6 +183,28 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
 
       int otherSize = Array.getLength(other);
       int actualSize = actual.size();
+      if (actualSize == otherSize) {
+        return;
+      }
+
+      throw assertionError(shouldHaveSameSizeAs(actual, other, actualSize, otherSize));
+    });
+  }
+
+  /**
+   * Verifies that the actual RichIterable matches the size of the given primitive iterable.
+   *
+   * @param other the primitive iterable to compare size with
+   * @return {@code this} assertion object
+   * @throws AssertionError if the actual RichIterable is {@code null}
+   * @throws AssertionError if the actual RichIterable does not have the same size as the given primitive iterable
+   */
+  public SELF hasSameSizeAs(PrimitiveIterable other) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      int actualSize = actual.size();
+      int otherSize = sizeOf(other);
       if (actualSize == otherSize) {
         return;
       }

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -17,6 +17,7 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldBeAnArray.shouldBeAnArray;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
@@ -34,12 +35,16 @@ import static org.assertj.eclipse.collections.util.RichIterableUtil.sizeOf;
 
 import java.lang.reflect.Array;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.assertj.core.annotation.CheckReturnValue;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.ThrowingConsumer;
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.PrimitiveIterable;
 import org.eclipse.collections.api.RichIterable;
@@ -90,6 +95,39 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  @Override
+  public SELF allSatisfy(Consumer<? super ELEMENT> requirements) {
+    return executeAssertion(() -> assertAllSatisfy(requirements));
+  }
+
+  @Override
+  public SELF allSatisfy(ThrowingConsumer<? super ELEMENT> requirements) {
+    return allSatisfy(((Consumer<? super ELEMENT>) requirements));
+  }
+
+  private void assertAllSatisfy(Consumer<? super ELEMENT> requirements) {
+    isNotNull();
+    isNotEmpty();
+    requireNonNull(requirements, "The Consumer<T> expressing the assertions requirements must not be null");
+
+    RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+      .collectIf(Optional::isPresent, Optional::get);
+    if (unsatisfiedRequirements.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+  }
+
+  private static <E> Optional<UnsatisfiedRequirement> failsRequirements(Consumer<? super E> requirements, E element) {
+    try {
+      requirements.accept(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   @Override

--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -20,6 +20,7 @@ import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldBeAnArray.shouldBeAnArray;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
+import static org.assertj.core.error.ShouldContain.shouldContain;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeBetween.shouldHaveSizeBetween;
@@ -42,6 +43,8 @@ import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 
 /**
  * Base class for implementations of Eclipse Collections {@link RichIterable} assertions.
@@ -86,6 +89,24 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  @Override
+  protected void assertContains(ELEMENT[] values) {
+    isNotNull();
+    requireNonNull(values, "The array of values to look for should not be null");
+
+    if (actual.isEmpty() && values.length == 0) {
+      return;
+    }
+
+    ArrayAdapter<ELEMENT> valuesList = ArrayAdapter.adapt(values);
+    MutableList<ELEMENT> notFound = valuesList.reject(actual::contains);
+    if (notFound.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(shouldContain(actual, valuesList, notFound)); // TODO: ComparisonStrategy???
   }
 
   @Override

--- a/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
@@ -15,14 +15,40 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.block.predicate.primitive.BooleanPredicate;
 import org.eclipse.collections.api.factory.primitive.BooleanLists;
+import org.eclipse.collections.api.list.primitive.BooleanList;
 
 public class BooleanIterableAssert extends AbstractPrimitiveIterableAssert<BooleanIterableAssert, BooleanIterable> {
   public BooleanIterableAssert(BooleanIterable actual) {
     super(actual, BooleanIterableAssert.class);
+  }
+
+  public BooleanIterableAssert allMatch(BooleanPredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public BooleanIterableAssert allMatch(BooleanPredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(BooleanPredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    BooleanList nonMatches = actual.reject(predicate).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public BooleanIterableAssert contains(boolean... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
@@ -17,11 +17,17 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.BooleanIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.primitive.BooleanPredicate;
+import org.eclipse.collections.api.block.procedure.primitive.BooleanProcedure;
 import org.eclipse.collections.api.factory.primitive.BooleanLists;
 import org.eclipse.collections.api.list.primitive.BooleanList;
 
@@ -49,6 +55,31 @@ public class BooleanIterableAssert extends AbstractPrimitiveIterableAssert<Boole
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public BooleanIterableAssert allSatisfy(BooleanProcedure requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The BooleanProcedure expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(BooleanProcedure requirements, boolean element) {
+    try {
+      requirements.value(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public BooleanIterableAssert contains(boolean... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
@@ -17,11 +17,17 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.primitive.BytePredicate;
+import org.eclipse.collections.api.block.procedure.primitive.ByteProcedure;
 import org.eclipse.collections.api.factory.primitive.ByteLists;
 import org.eclipse.collections.api.list.primitive.ByteList;
 
@@ -50,6 +56,31 @@ public class ByteIterableAssert extends AbstractPrimitiveIterableAssert<ByteIter
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public ByteIterableAssert allSatisfy(ByteProcedure requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The ByteProcedure expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(ByteProcedure requirements, byte element) {
+    try {
+      requirements.value(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public ByteIterableAssert contains(byte... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
@@ -15,15 +15,41 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.ByteIterable;
+import org.eclipse.collections.api.block.predicate.primitive.BytePredicate;
 import org.eclipse.collections.api.factory.primitive.ByteLists;
+import org.eclipse.collections.api.list.primitive.ByteList;
 
 public class ByteIterableAssert extends AbstractPrimitiveIterableAssert<ByteIterableAssert, ByteIterable> {
 
   public ByteIterableAssert(ByteIterable actual) {
     super(actual, ByteIterableAssert.class);
+  }
+
+  public ByteIterableAssert allMatch(BytePredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public ByteIterableAssert allMatch(BytePredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(BytePredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    ByteList nonMatches = actual.reject(predicate).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public ByteIterableAssert contains(byte... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
@@ -17,11 +17,17 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.primitive.CharPredicate;
+import org.eclipse.collections.api.block.procedure.primitive.CharProcedure;
 import org.eclipse.collections.api.factory.primitive.CharLists;
 import org.eclipse.collections.api.list.primitive.CharList;
 
@@ -49,6 +55,31 @@ public class CharIterableAssert extends AbstractPrimitiveIterableAssert<CharIter
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public CharIterableAssert allSatisfy(CharProcedure requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The CharProcedure expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(CharProcedure requirements, char element) {
+    try {
+      requirements.value(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public CharIterableAssert contains(char... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
@@ -15,14 +15,40 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.CharIterable;
+import org.eclipse.collections.api.block.predicate.primitive.CharPredicate;
 import org.eclipse.collections.api.factory.primitive.CharLists;
+import org.eclipse.collections.api.list.primitive.CharList;
 
 public class CharIterableAssert extends AbstractPrimitiveIterableAssert<CharIterableAssert, CharIterable> {
   public CharIterableAssert(CharIterable actual) {
     super(actual, CharIterableAssert.class);
+  }
+
+  public CharIterableAssert allMatch(CharPredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public CharIterableAssert allMatch(CharPredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(CharPredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    CharList nonMatches = actual.reject(predicate).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public CharIterableAssert contains(char... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
@@ -17,12 +17,17 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+import java.util.function.DoubleConsumer;
 import java.util.function.DoublePredicate;
 
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.DoubleIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.primitive.DoubleLists;
 import org.eclipse.collections.api.list.primitive.DoubleList;
 
@@ -50,6 +55,31 @@ public class DoubleIterableAssert extends AbstractPrimitiveIterableAssert<Double
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public DoubleIterableAssert allSatisfy(DoubleConsumer requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The DoubleConsumer expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(DoubleConsumer requirements, double element) {
+    try {
+      requirements.accept(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public DoubleIterableAssert contains(double... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
@@ -15,14 +15,41 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.function.DoublePredicate;
+
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.DoubleIterable;
 import org.eclipse.collections.api.factory.primitive.DoubleLists;
+import org.eclipse.collections.api.list.primitive.DoubleList;
 
 public class DoubleIterableAssert extends AbstractPrimitiveIterableAssert<DoubleIterableAssert, DoubleIterable> {
   public DoubleIterableAssert(DoubleIterable actual) {
     super(actual, DoubleIterableAssert.class);
+  }
+
+  public DoubleIterableAssert allMatch(DoublePredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public DoubleIterableAssert allMatch(DoublePredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(DoublePredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    DoubleList nonMatches = actual.reject(predicate::test).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public DoubleIterableAssert contains(double... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
@@ -15,14 +15,40 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.api.block.predicate.primitive.FloatPredicate;
 import org.eclipse.collections.api.factory.primitive.FloatLists;
+import org.eclipse.collections.api.list.primitive.FloatList;
 
 public class FloatIterableAssert extends AbstractPrimitiveIterableAssert<FloatIterableAssert, FloatIterable> {
   public FloatIterableAssert(FloatIterable actual) {
     super(actual, FloatIterableAssert.class);
+  }
+
+  public FloatIterableAssert allMatch(FloatPredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public FloatIterableAssert allMatch(FloatPredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(FloatPredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    FloatList nonMatches = actual.reject(predicate).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public FloatIterableAssert contains(float... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
@@ -17,11 +17,17 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.FloatIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.block.predicate.primitive.FloatPredicate;
+import org.eclipse.collections.api.block.procedure.primitive.FloatProcedure;
 import org.eclipse.collections.api.factory.primitive.FloatLists;
 import org.eclipse.collections.api.list.primitive.FloatList;
 
@@ -49,6 +55,31 @@ public class FloatIterableAssert extends AbstractPrimitiveIterableAssert<FloatIt
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public FloatIterableAssert allSatisfy(FloatProcedure requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The FloatProcedure expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(FloatProcedure requirements, float element) {
+    try {
+      requirements.value(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public FloatIterableAssert contains(float... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
@@ -17,12 +17,17 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+import java.util.function.IntConsumer;
 import java.util.function.IntPredicate;
 
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.IntIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.primitive.IntLists;
 import org.eclipse.collections.api.list.primitive.IntList;
 
@@ -50,6 +55,31 @@ public class IntIterableAssert extends AbstractPrimitiveIterableAssert<IntIterab
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public IntIterableAssert allSatisfy(IntConsumer requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The IntConsumer expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(IntConsumer requirements, int element) {
+    try {
+      requirements.accept(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public IntIterableAssert contains(int... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
@@ -15,14 +15,41 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.function.IntPredicate;
+
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.IntIterable;
 import org.eclipse.collections.api.factory.primitive.IntLists;
+import org.eclipse.collections.api.list.primitive.IntList;
 
 public class IntIterableAssert extends AbstractPrimitiveIterableAssert<IntIterableAssert, IntIterable> {
   public IntIterableAssert(IntIterable actual) {
     super(actual, IntIterableAssert.class);
+  }
+
+  public IntIterableAssert allMatch(IntPredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public IntIterableAssert allMatch(IntPredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(IntPredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    IntList nonMatches = actual.reject(predicate::test).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public IntIterableAssert contains(int... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
@@ -17,14 +17,19 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+import java.util.function.LongConsumer;
+import java.util.function.LongPredicate;
+
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.LongIterable;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.primitive.LongLists;
 import org.eclipse.collections.api.list.primitive.LongList;
-
-import java.util.function.LongPredicate;
 
 public class LongIterableAssert extends AbstractPrimitiveIterableAssert<LongIterableAssert, LongIterable> {
   public LongIterableAssert(LongIterable actual) {
@@ -50,6 +55,31 @@ public class LongIterableAssert extends AbstractPrimitiveIterableAssert<LongIter
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public LongIterableAssert allSatisfy(LongConsumer requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The LongConsumer expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(LongConsumer requirements, long element) {
+    try {
+      requirements.accept(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public LongIterableAssert contains(long... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
@@ -15,14 +15,41 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.LongIterable;
 import org.eclipse.collections.api.factory.primitive.LongLists;
+import org.eclipse.collections.api.list.primitive.LongList;
+
+import java.util.function.LongPredicate;
 
 public class LongIterableAssert extends AbstractPrimitiveIterableAssert<LongIterableAssert, LongIterable> {
   public LongIterableAssert(LongIterable actual) {
     super(actual, LongIterableAssert.class);
+  }
+
+  public LongIterableAssert allMatch(LongPredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public LongIterableAssert allMatch(LongPredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(LongPredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    LongList nonMatches = actual.reject(predicate::test).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public LongIterableAssert contains(long... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
@@ -17,11 +17,17 @@ package org.assertj.eclipse.collections.api;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
+import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import java.util.Optional;
+
+import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.presentation.PredicateDescription;
+import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.block.predicate.primitive.ShortPredicate;
+import org.eclipse.collections.api.block.procedure.primitive.ShortProcedure;
 import org.eclipse.collections.api.factory.primitive.ShortLists;
 import org.eclipse.collections.api.list.primitive.ShortList;
 
@@ -49,6 +55,31 @@ public class ShortIterableAssert extends AbstractPrimitiveIterableAssert<ShortIt
     }
 
     throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
+  }
+
+  public ShortIterableAssert allSatisfy(ShortProcedure requirements) {
+    return executeAssertion(() -> {
+      isNotNull();
+      isNotEmpty();
+      requireNonNull(requirements, "The ShortProcedure expressing the assertions requirements must not be null");
+
+      RichIterable<UnsatisfiedRequirement> unsatisfiedRequirements = actual.collect(element -> failsRequirements(requirements, element))
+        .collectIf(Optional::isPresent, Optional::get);
+      if (unsatisfiedRequirements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(elementsShouldSatisfy(actual, unsatisfiedRequirements.toList(), info));
+    });
+  }
+
+  private static Optional<UnsatisfiedRequirement> failsRequirements(ShortProcedure requirements, short element) {
+    try {
+      requirements.value(element);
+    } catch (AssertionError ex) {
+      return Optional.of(new UnsatisfiedRequirement(element, ex));
+    }
+    return Optional.empty();
   }
 
   public ShortIterableAssert contains(short... values) {

--- a/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
@@ -15,14 +15,40 @@
  */
 package org.assertj.eclipse.collections.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ShouldContain.shouldContain;
 
+import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.ShortIterable;
+import org.eclipse.collections.api.block.predicate.primitive.ShortPredicate;
 import org.eclipse.collections.api.factory.primitive.ShortLists;
+import org.eclipse.collections.api.list.primitive.ShortList;
 
 public class ShortIterableAssert extends AbstractPrimitiveIterableAssert<ShortIterableAssert, ShortIterable> {
   public ShortIterableAssert(ShortIterable actual) {
     super(actual, ShortIterableAssert.class);
+  }
+
+  public ShortIterableAssert allMatch(ShortPredicate predicate) {
+    return executeAssertion(() -> assertAllMatch(predicate, PredicateDescription.GIVEN));
+  }
+
+  public ShortIterableAssert allMatch(ShortPredicate predicate, String predicateDescription) {
+    return executeAssertion(() -> assertAllMatch(predicate, new PredicateDescription(predicateDescription)));
+  }
+
+  private void assertAllMatch(ShortPredicate predicate, PredicateDescription predicateDescription) {
+    isNotNull();
+    requireNonNull(predicate, "The predicate to evaluate should not be null");
+    isNotEmpty();
+
+    ShortList nonMatches = actual.reject(predicate).toList();
+    if (nonMatches.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(elementsShouldMatch(actual, nonMatches.size() == 1 ? nonMatches.getFirst() : nonMatches, predicateDescription));
   }
 
   public ShortIterableAssert contains(short... values) {

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_AllMatch_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_AllMatch_Test.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BooleanIterableAssert;
+import org.assertj.eclipse.collections.api.ByteIterableAssert;
+import org.assertj.eclipse.collections.api.CharIterableAssert;
+import org.assertj.eclipse.collections.api.DoubleIterableAssert;
+import org.assertj.eclipse.collections.api.FloatIterableAssert;
+import org.assertj.eclipse.collections.api.IntIterableAssert;
+import org.assertj.eclipse.collections.api.LongIterableAssert;
+import org.assertj.eclipse.collections.api.ShortIterableAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.junit.jupiter.api.Nested;
+
+class PrimitiveIterableAssert_AllMatch_Test {
+
+  @Nested
+  class BooleanTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void passes(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(true, true, true).allMatch(value -> value));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void failsEmpty(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void fails(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(true, false, true).allMatch(value -> value))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void passesWithDescription(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(true, true, true).allMatch(value -> value, "is true"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void failsWithDescription(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(true, false, true).allMatch(value -> value, "is true"))
+        .withMessageContaining("to match 'is true' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> true));
+    }
+  }
+
+  @Nested
+  class ByteTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void passes(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((byte) 2, (byte) 4, (byte) 6).allMatch(value -> value % 2 == 0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void failsEmpty(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value % 2 == 0))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void fails(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((byte) 2, (byte) 3, (byte) 4).allMatch(value -> value % 2 == 0))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void passesWithDescription(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((byte) 2, (byte) 4, (byte) 6).allMatch(value -> value % 2 == 0, "is even"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void failsWithDescription(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((byte) 2, (byte) 3, (byte) 4).allMatch(value -> value % 2 == 0, "is even"))
+        .withMessageContaining("to match 'is even' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> value >= 0));
+    }
+  }
+
+  @Nested
+  class CharTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void passes(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements('a', 'b', 'c').allMatch(value -> value >= 'a' && value <= 'z'));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void failsEmpty(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value >= 'a' && value <= 'z'))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void fails(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements('a', 'Z', 'c').allMatch(value -> value >= 'a' && value <= 'z'))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void passesWithDescription(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements('a', 'b', 'c').allMatch(value -> value >= 'a' && value <= 'z', "is lowercase"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void failsWithDescription(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements('a', 'Z', 'c').allMatch(value -> value >= 'a' && value <= 'z', "is lowercase"))
+        .withMessageContaining("to match 'is lowercase' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> value >= 0));
+    }
+  }
+
+  @Nested
+  class DoubleTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void passes(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2.0, 4.0, 6.0).allMatch(value -> value > 0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void failsEmpty(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value > 0))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void fails(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2.0, -1.0, 4.0).allMatch(value -> value > 0))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void passesWithDescription(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2.0, 4.0, 6.0).allMatch(value -> value > 0, "is positive"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void failsWithDescription(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2.0, -1.0, 4.0).allMatch(value -> value > 0, "is positive"))
+        .withMessageContaining("to match 'is positive' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> value >= 0));
+    }
+  }
+
+  @Nested
+  class FloatTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void passes(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2.0f, 4.0f, 6.0f).allMatch(value -> value > 0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void failsEmpty(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value > 0))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void fails(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2.0f, -1.0f, 4.0f).allMatch(value -> value > 0))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void passesWithDescription(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2.0f, 4.0f, 6.0f).allMatch(value -> value > 0, "is positive"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void failsWithDescription(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2.0f, -1.0f, 4.0f).allMatch(value -> value > 0, "is positive"))
+        .withMessageContaining("to match 'is positive' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> value >= 0));
+    }
+  }
+
+  @Nested
+  class IntTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void passes(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2, 4, 6).allMatch(value -> value % 2 == 0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void failsEmpty(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value % 2 == 0))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void fails(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2, 3, 4).allMatch(value -> value % 2 == 0))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void passesWithDescription(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2, 4, 6).allMatch(value -> value % 2 == 0, "is even"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void failsWithDescription(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2, 3, 4).allMatch(value -> value % 2 == 0, "is even"))
+        .withMessageContaining("to match 'is even' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> value >= 0));
+    }
+  }
+
+  @Nested
+  class LongTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void passes(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2L, 4L, 6L).allMatch(value -> value % 2 == 0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void failsEmpty(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value % 2 == 0))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void fails(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2L, 3L, 4L).allMatch(value -> value % 2 == 0))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void passesWithDescription(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2L, 4L, 6L).allMatch(value -> value % 2 == 0, "is even"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void failsWithDescription(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2L, 3L, 4L).allMatch(value -> value % 2 == 0, "is even"))
+        .withMessageContaining("to match 'is even' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> value >= 0));
+    }
+  }
+
+  @Nested
+  class ShortTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void passes(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((short) 2, (short) 4, (short) 6).allMatch(value -> value % 2 == 0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void failsEmpty(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allMatch(value -> value % 2 == 0))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void fails(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((short) 2, (short) 3, (short) 4).allMatch(value -> value % 2 == 0))
+        .withMessageContaining("to match given predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void passesWithDescription(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((short) 2, (short) 4, (short) 6).allMatch(value -> value % 2 == 0, "is even"));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void failsWithDescription(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((short) 2, (short) 3, (short) 4).allMatch(value -> value % 2 == 0, "is even"))
+        .withMessageContaining("to match 'is even' predicate but this element did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allMatch(value -> value >= 0));
+    }
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_AllSatisfy_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_AllSatisfy_Test.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BooleanIterableAssert;
+import org.assertj.eclipse.collections.api.ByteIterableAssert;
+import org.assertj.eclipse.collections.api.CharIterableAssert;
+import org.assertj.eclipse.collections.api.DoubleIterableAssert;
+import org.assertj.eclipse.collections.api.FloatIterableAssert;
+import org.assertj.eclipse.collections.api.IntIterableAssert;
+import org.assertj.eclipse.collections.api.LongIterableAssert;
+import org.assertj.eclipse.collections.api.ShortIterableAssert;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+import org.junit.jupiter.api.Nested;
+
+class PrimitiveIterableAssert_AllSatisfy_Test {
+
+  @Nested
+  class BooleanTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void passes(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(true, true, true).allSatisfy(value -> assertThat(value).isTrue()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void failsEmpty(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isTrue()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void fails(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(true, false, true).allSatisfy(value -> assertThat(value).isTrue()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> {
+      }));
+    }
+  }
+
+  @Nested
+  class ByteTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void passes(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((byte) 2, (byte) 4, (byte) 6).allSatisfy(value -> assertThat(value).isEven()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void failsEmpty(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void fails(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((byte) 2, (byte) 3, (byte) 4).allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> assertThat(value).isGreaterThanOrEqualTo((byte) 0)));
+    }
+  }
+
+  @Nested
+  class CharTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void passes(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements('a', 'b', 'c').allSatisfy(value -> assertThat(value).isLowerCase()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void failsEmpty(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isLowerCase()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void fails(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements('a', 'Z', 'c').allSatisfy(value -> assertThat(value).isLowerCase()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> assertThat(value).isGreaterThanOrEqualTo((char) 0)));
+    }
+  }
+
+  @Nested
+  class DoubleTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void passes(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2.0, 4.0, 6.0).allSatisfy(value -> assertThat(value).isPositive()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void failsEmpty(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isPositive()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void fails(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2.0, -1.0, 4.0).allSatisfy(value -> assertThat(value).isPositive()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> assertThat(value).isGreaterThanOrEqualTo(0.0)));
+    }
+  }
+
+  @Nested
+  class FloatTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void passes(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2.0f, 4.0f, 6.0f).allSatisfy(value -> assertThat(value).isPositive()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void failsEmpty(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isPositive()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void fails(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2.0f, -1.0f, 4.0f).allSatisfy(value -> assertThat(value).isPositive()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> assertThat(value).isGreaterThanOrEqualTo(0.0f)));
+    }
+  }
+
+  @Nested
+  class IntTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void passes(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2, 4, 6).allSatisfy(value -> assertThat(value).isEven()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void failsEmpty(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void fails(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2, 3, 4).allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> assertThat(value).isGreaterThanOrEqualTo(0)));
+    }
+  }
+
+  @Nested
+  class LongTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void passes(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(2L, 4L, 6L).allSatisfy(value -> assertThat(value).isEven()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void failsEmpty(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void fails(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(2L, 3L, 4L).allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> assertThat(value).isGreaterThanOrEqualTo(0L)));
+    }
+  }
+
+  @Nested
+  class ShortTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void passes(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((short) 2, (short) 4, (short) 6).allSatisfy(value -> assertThat(value).isEven()));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void failsEmpty(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("Expecting actual not to be empty");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void fails(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((short) 2, (short) 3, (short) 4).allSatisfy(value -> assertThat(value).isEven()))
+        .withMessageContaining("to satisfy given requirements, but these elements did not:");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void softAssertionPasses(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromSize(softly, 3).allSatisfy(value -> assertThat(value).isGreaterThanOrEqualTo((short) 0)));
+    }
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_AllSatisfy_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_AllSatisfy_Test.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.ThrowingConsumer;
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_AllSatisfy_Test {
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allSatisfy((Consumer<String>) s ->
+        assertThat(s).hasSize(3)));
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().allSatisfy((Consumer<String>) s ->
+        assertThat(s).hasSize(3)))
+      .withMessageContaining("Expecting actual not to be empty");
+  }
+
+  @RichIterableParameterizedTest
+  void fails(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allSatisfy((Consumer<String>) s ->
+        assertThat(s).doesNotContain("9")))
+      .withMessageContaining("to satisfy given requirements, but these elements did not:");
+  }
+
+  @SuppressWarnings("RedundantCast")
+  @RichIterableParameterizedTest
+  void passesThrowingConsumer(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allSatisfy((ThrowingConsumer<String>) s ->
+        assertThat(s).hasSize(3)));
+  }
+
+  @SuppressWarnings("RedundantCast")
+  @RichIterableParameterizedTest
+  void failsThrowingConsumer(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").allSatisfy((ThrowingConsumer<String>) s ->
+        assertThat(s).doesNotContain("9")))
+      .withMessageContaining("to satisfy given requirements, but these elements did not:");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").allSatisfy((Consumer<String>) s ->
+      assertThat(s).hasSize(3)));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_Contains_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_Contains_Test.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_Contains_Test {
+  @RichIterableParameterizedTest
+  void passesSingleValue(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").contains("DS9"));
+  }
+
+  @RichIterableParameterizedTest
+  void passesMultipleValues(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").contains("TOS", "VOY", "ENT"));
+  }
+
+  @RichIterableParameterizedTest
+  void passesBothEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().contains());
+  }
+
+  @RichIterableParameterizedTest
+  void fails(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").contains("DIS"))
+      .withMessageContaining("to contain")
+      .withMessageContaining("but could not find the following element(s)")
+      .withMessageContaining("DIS");
+  }
+
+  @RichIterableParameterizedTest
+  void failsWithMultipleValues(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").contains("DS9", "DIS"))
+      .withMessageContaining("to contain")
+      .withMessageContaining("but could not find the following element(s)")
+      .withMessageContaining("DIS");
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().contains("DS9"))
+      .withMessageContaining("to contain")
+      .withMessageContaining("but could not find the following element(s)")
+      .withMessageContaining("DS9");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNull(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().contains("DS9"))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(NullPointerException.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").contains(null))
+      .withMessageContaining("The array of values to look for should not be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").contains("DS9"));
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSameSizeAs_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_HasSameSizeAs_Test.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.assertj.eclipse.collections.api.SoftAssertions;
 import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.primitive.IntLists;
 
 class AbstractRichIterableAssert_HasSameSizeAs_Test {
 
@@ -98,5 +99,30 @@ class AbstractRichIterableAssert_HasSameSizeAs_Test {
   @RichIterableParameterizedTest
   void softAssertionPassesArray(RichIterableAssertFactory<String> assertFactory) {
     SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(new String[]{"a", "b", "c", "d", "e"}));
+  }
+
+  @RichIterableParameterizedTest
+  void passesPrimitiveIterable(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(IntLists.immutable.of(1, 2, 3, 4, 5)));
+  }
+
+  @RichIterableParameterizedTest
+  void failsPrimitiveIterableDifferentSize(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(IntLists.immutable.of(1, 2, 3)))
+      .withMessageContaining("Actual and expected should have same size but actual size is:");
+  }
+
+  @RichIterableParameterizedTest
+  void failsPrimitiveIterableNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().hasSameSizeAs(IntLists.immutable.of(1, 2, 3, 4, 5)))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPassesPrimitiveIterable(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").hasSameSizeAs(IntLists.immutable.of(1, 2, 3, 4, 5)));
   }
 }


### PR DESCRIPTION
Continuing work on building out RichIterable and PrimitiveIterable assertions. This includes allSatisfy, allMatch, and contains.