### PR TITLE
Add doesNotContain assertion for primitive and rich iterables

### DIFF
--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -30,6 +30,7 @@ import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHa
 import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
 import static org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo.shouldHaveSizeLessThanOrEqualTo;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.eclipse.collections.util.RichIterableUtil.sizeOf;
 
@@ -146,6 +147,21 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldContain(actual, valuesList, notFound)); // TODO: ComparisonStrategy???
+  }
+
+  @Override
+  protected void assertDoesNotContain(ELEMENT[] values) {
+    isNotNull();
+    requireNonNull(values, "The array of values to look for should not be null");
+
+    ArrayAdapter<ELEMENT> valuesList = ArrayAdapter.adapt(values);
+    MutableList<ELEMENT> found = valuesList.select(actual::contains);
+
+    if (found.isEmpty()) {
+      return;
+    }
+
+    throw assertionError(shouldNotContain(actual, valuesList, found)); // TODO: ComparisonStrategy???
   }
 
   @Override

--- a/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/BooleanIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 
@@ -30,6 +31,7 @@ import org.eclipse.collections.api.block.predicate.primitive.BooleanPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.BooleanProcedure;
 import org.eclipse.collections.api.factory.primitive.BooleanLists;
 import org.eclipse.collections.api.list.primitive.BooleanList;
+import org.eclipse.collections.api.list.primitive.ImmutableBooleanList;
 
 public class BooleanIterableAssert extends AbstractPrimitiveIterableAssert<BooleanIterableAssert, BooleanIterable> {
   public BooleanIterableAssert(BooleanIterable actual) {
@@ -93,6 +95,19 @@ public class BooleanIterableAssert extends AbstractPrimitiveIterableAssert<Boole
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public BooleanIterableAssert doesNotContain(boolean... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableBooleanList found = BooleanLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ByteIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 
@@ -30,6 +31,7 @@ import org.eclipse.collections.api.block.predicate.primitive.BytePredicate;
 import org.eclipse.collections.api.block.procedure.primitive.ByteProcedure;
 import org.eclipse.collections.api.factory.primitive.ByteLists;
 import org.eclipse.collections.api.list.primitive.ByteList;
+import org.eclipse.collections.api.list.primitive.ImmutableByteList;
 
 public class ByteIterableAssert extends AbstractPrimitiveIterableAssert<ByteIterableAssert, ByteIterable> {
 
@@ -94,6 +96,19 @@ public class ByteIterableAssert extends AbstractPrimitiveIterableAssert<ByteIter
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public ByteIterableAssert doesNotContain(byte... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableByteList found = ByteLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/CharIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 
@@ -30,6 +31,7 @@ import org.eclipse.collections.api.block.predicate.primitive.CharPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.CharProcedure;
 import org.eclipse.collections.api.factory.primitive.CharLists;
 import org.eclipse.collections.api.list.primitive.CharList;
+import org.eclipse.collections.api.list.primitive.ImmutableCharList;
 
 public class CharIterableAssert extends AbstractPrimitiveIterableAssert<CharIterableAssert, CharIterable> {
   public CharIterableAssert(CharIterable actual) {
@@ -93,6 +95,19 @@ public class CharIterableAssert extends AbstractPrimitiveIterableAssert<CharIter
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public CharIterableAssert doesNotContain(char... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableCharList found = CharLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/DoubleIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 import java.util.function.DoubleConsumer;
@@ -30,6 +31,7 @@ import org.eclipse.collections.api.DoubleIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.primitive.DoubleLists;
 import org.eclipse.collections.api.list.primitive.DoubleList;
+import org.eclipse.collections.api.list.primitive.ImmutableDoubleList;
 
 public class DoubleIterableAssert extends AbstractPrimitiveIterableAssert<DoubleIterableAssert, DoubleIterable> {
   public DoubleIterableAssert(DoubleIterable actual) {
@@ -93,6 +95,19 @@ public class DoubleIterableAssert extends AbstractPrimitiveIterableAssert<Double
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public DoubleIterableAssert doesNotContain(double... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableDoubleList found = DoubleLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/FloatIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 
@@ -30,6 +31,7 @@ import org.eclipse.collections.api.block.predicate.primitive.FloatPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.FloatProcedure;
 import org.eclipse.collections.api.factory.primitive.FloatLists;
 import org.eclipse.collections.api.list.primitive.FloatList;
+import org.eclipse.collections.api.list.primitive.ImmutableFloatList;
 
 public class FloatIterableAssert extends AbstractPrimitiveIterableAssert<FloatIterableAssert, FloatIterable> {
   public FloatIterableAssert(FloatIterable actual) {
@@ -93,6 +95,19 @@ public class FloatIterableAssert extends AbstractPrimitiveIterableAssert<FloatIt
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public FloatIterableAssert doesNotContain(float... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableFloatList found = FloatLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/IntIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 import java.util.function.IntConsumer;
@@ -29,6 +30,7 @@ import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.IntIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.primitive.IntLists;
+import org.eclipse.collections.api.list.primitive.ImmutableIntList;
 import org.eclipse.collections.api.list.primitive.IntList;
 
 public class IntIterableAssert extends AbstractPrimitiveIterableAssert<IntIterableAssert, IntIterable> {
@@ -87,12 +89,24 @@ public class IntIterableAssert extends AbstractPrimitiveIterableAssert<IntIterab
       isNotNull();
 
       IntIterable notFound = IntLists.immutable.of(values).reject(actual::contains);
-
       if (notFound.isEmpty()) {
         return;
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public IntIterableAssert doesNotContain(int... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableIntList found = IntLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/LongIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 import java.util.function.LongConsumer;
@@ -29,6 +30,7 @@ import org.assertj.core.presentation.PredicateDescription;
 import org.eclipse.collections.api.LongIterable;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.primitive.LongLists;
+import org.eclipse.collections.api.list.primitive.ImmutableLongList;
 import org.eclipse.collections.api.list.primitive.LongList;
 
 public class LongIterableAssert extends AbstractPrimitiveIterableAssert<LongIterableAssert, LongIterable> {
@@ -93,6 +95,19 @@ public class LongIterableAssert extends AbstractPrimitiveIterableAssert<LongIter
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public LongIterableAssert doesNotContain(long... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableLongList found = LongLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/ShortIterableAssert.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.ElementsShouldMatch.elementsShouldMatch;
 import static org.assertj.core.error.ElementsShouldSatisfy.elementsShouldSatisfy;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
 
 import java.util.Optional;
 
@@ -29,6 +30,7 @@ import org.eclipse.collections.api.ShortIterable;
 import org.eclipse.collections.api.block.predicate.primitive.ShortPredicate;
 import org.eclipse.collections.api.block.procedure.primitive.ShortProcedure;
 import org.eclipse.collections.api.factory.primitive.ShortLists;
+import org.eclipse.collections.api.list.primitive.ImmutableShortList;
 import org.eclipse.collections.api.list.primitive.ShortList;
 
 public class ShortIterableAssert extends AbstractPrimitiveIterableAssert<ShortIterableAssert, ShortIterable> {
@@ -93,6 +95,19 @@ public class ShortIterableAssert extends AbstractPrimitiveIterableAssert<ShortIt
       }
 
       throw assertionError(shouldContain(actual, values, notFound));
+    });
+  }
+
+  public ShortIterableAssert doesNotContain(short... values) {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      ImmutableShortList found = ShortLists.immutable.of(values).select(actual::contains);
+      if (found.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldNotContain(actual, values, found));
     });
   }
 }

--- a/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_DoesNotContain_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/primitive/PrimitiveIterableAssert_DoesNotContain_Test.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.primitive;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import org.assertj.eclipse.collections.api.BooleanIterableAssert;
+import org.assertj.eclipse.collections.api.ByteIterableAssert;
+import org.assertj.eclipse.collections.api.CharIterableAssert;
+import org.assertj.eclipse.collections.api.DoubleIterableAssert;
+import org.assertj.eclipse.collections.api.FloatIterableAssert;
+import org.assertj.eclipse.collections.api.IntIterableAssert;
+import org.assertj.eclipse.collections.api.LongIterableAssert;
+import org.assertj.eclipse.collections.api.ShortIterableAssert;
+import org.junit.jupiter.api.Nested;
+
+class PrimitiveIterableAssert_DoesNotContain_Test {
+
+  @Nested
+  class BooleanTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void passes(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(false, false, false).doesNotContain(true));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void passesEmpty(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain(true));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void fails(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(false, false, false).doesNotContain(false))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BOOLEAN)
+    void failsNull(PrimitiveIterableAssertFactory<BooleanIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain(true))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+
+  @Nested
+  class ByteTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void passes(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((byte) 1, (byte) 2, (byte) 3).doesNotContain((byte) 99));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void passesMultipleValues(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((byte) 1, (byte) 2, (byte) 3).doesNotContain((byte) 97, (byte) 98, (byte) 99));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void passesEmpty(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain((byte) 1));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void fails(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((byte) 1, (byte) 2, (byte) 3).doesNotContain((byte) 2))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void failsWithMultipleValues(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((byte) 1, (byte) 2, (byte) 3).doesNotContain((byte) 99, (byte) 2))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.BYTE)
+    void failsNull(PrimitiveIterableAssertFactory<ByteIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain((byte) 1))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+
+  @Nested
+  class CharTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void passes(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements('a', 'b', 'c').doesNotContain('z'));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void passesMultipleValues(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements('a', 'b', 'c').doesNotContain('x', 'y', 'z'));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void passesEmpty(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain('a'));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void fails(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements('a', 'b', 'c').doesNotContain('b'))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void failsWithMultipleValues(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements('a', 'b', 'c').doesNotContain('z', 'b'))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.CHAR)
+    void failsNull(PrimitiveIterableAssertFactory<CharIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain('a'))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+
+  @Nested
+  class DoubleTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void passes(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1.0, 2.0, 3.0).doesNotContain(99.0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void passesMultipleValues(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1.0, 2.0, 3.0).doesNotContain(97.0, 98.0, 99.0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void passesEmpty(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain(1.0));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void fails(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1.0, 2.0, 3.0).doesNotContain(2.0))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void failsWithMultipleValues(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1.0, 2.0, 3.0).doesNotContain(99.0, 2.0))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.DOUBLE)
+    void failsNull(PrimitiveIterableAssertFactory<DoubleIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain(1.0))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+
+  @Nested
+  class FloatTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void passes(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1.0f, 2.0f, 3.0f).doesNotContain(99.0f));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void passesMultipleValues(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1.0f, 2.0f, 3.0f).doesNotContain(97.0f, 98.0f, 99.0f));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void passesEmpty(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain(1.0f));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void fails(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1.0f, 2.0f, 3.0f).doesNotContain(2.0f))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void failsWithMultipleValues(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1.0f, 2.0f, 3.0f).doesNotContain(99.0f, 2.0f))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.FLOAT)
+    void failsNull(PrimitiveIterableAssertFactory<FloatIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain(1.0f))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+
+  @Nested
+  class IntTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void passes(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1, 2, 3).doesNotContain(99));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void passesMultipleValues(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1, 2, 3).doesNotContain(97, 98, 99));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void passesEmpty(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain(1));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void fails(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1, 2, 3).doesNotContain(2))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void failsWithMultipleValues(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1, 2, 3).doesNotContain(99, 2))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.INT)
+    void failsNull(PrimitiveIterableAssertFactory<IntIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain(1))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+
+  @Nested
+  class LongTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void passes(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1L, 2L, 3L).doesNotContain(99L));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void passesMultipleValues(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements(1L, 2L, 3L).doesNotContain(97L, 98L, 99L));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void passesEmpty(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain(1L));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void fails(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1L, 2L, 3L).doesNotContain(2L))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void failsWithMultipleValues(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements(1L, 2L, 3L).doesNotContain(99L, 2L))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.LONG)
+    void failsNull(PrimitiveIterableAssertFactory<LongIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain(1L))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+
+  @Nested
+  class ShortTest {
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void passes(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((short) 1, (short) 2, (short) 3).doesNotContain((short) 99));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void passesMultipleValues(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromElements((short) 1, (short) 2, (short) 3).doesNotContain((short) 97, (short) 98, (short) 99));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void passesEmpty(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatNoException().isThrownBy(() ->
+        assertFactory.fromEmpty().doesNotContain((short) 1));
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void fails(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((short) 1, (short) 2, (short) 3).doesNotContain((short) 2))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void failsWithMultipleValues(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromElements((short) 1, (short) 2, (short) 3).doesNotContain((short) 99, (short) 2))
+        .withMessageContaining("not to contain")
+        .withMessageContaining("but found");
+    }
+
+    @PrimitiveIterableParameterizedTest(type = PrimitiveType.SHORT)
+    void failsNull(PrimitiveIterableAssertFactory<ShortIterableAssert> assertFactory) {
+      assertThatExceptionOfType(AssertionError.class)
+        .isThrownBy(() -> assertFactory.fromNull().doesNotContain((short) 1))
+        .withMessageContaining("Expecting actual not to be null");
+    }
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_DoesNotContain_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_DoesNotContain_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_DoesNotContain_Test {
+  @RichIterableParameterizedTest
+  void passesSingleValue(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").doesNotContain("DIS"));
+  }
+
+  @RichIterableParameterizedTest
+  void passesMultipleValues(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").doesNotContain("DIS", "PIC", "SNW"));
+  }
+
+  @RichIterableParameterizedTest
+  void passesEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().doesNotContain("DS9"));
+  }
+
+  @RichIterableParameterizedTest
+  void fails(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").doesNotContain("DS9"))
+      .withMessageContaining("not to contain")
+      .withMessageContaining("but found")
+      .withMessageContaining("DS9");
+  }
+
+  @RichIterableParameterizedTest
+  void failsWithMultipleValues(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").doesNotContain("DIS", "DS9"))
+      .withMessageContaining("not to contain")
+      .withMessageContaining("but found")
+      .withMessageContaining("DS9");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNull(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().doesNotContain("DS9"))
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNullInput(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(NullPointerException.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").doesNotContain(null))
+      .withMessageContaining("The array of values to look for should not be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").doesNotContain("DIS"));
+  }
+}


### PR DESCRIPTION
Adding support for the doesNotContain method for both RichIterable and PrimitiveIterable.