### PR TITLE
Add containsNull, doesNotContainNull, and containsOnlyNulls assertions

### DIFF
--- a/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
+++ b/src/main/java/org/assertj/eclipse/collections/api/AbstractRichIterableAssert.java
@@ -22,6 +22,8 @@ import static org.assertj.core.error.ShouldBeAnArray.shouldBeAnArray;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.error.ShouldContain.shouldContain;
+import static org.assertj.core.error.ShouldContainNull.shouldContainNull;
+import static org.assertj.core.error.ShouldContainOnlyNulls.shouldContainOnlyNulls;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldHaveSizeBetween.shouldHaveSizeBetween;
@@ -31,6 +33,7 @@ import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessTh
 import static org.assertj.core.error.ShouldHaveSizeLessThanOrEqualTo.shouldHaveSizeLessThanOrEqualTo;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.error.ShouldNotContain.shouldNotContain;
+import static org.assertj.core.error.ShouldNotContainNull.shouldNotContainNull;
 import static org.assertj.core.util.Preconditions.checkArgument;
 import static org.assertj.eclipse.collections.util.RichIterableUtil.sizeOf;
 
@@ -162,6 +165,50 @@ public abstract class AbstractRichIterableAssert<SELF extends AbstractRichIterab
     }
 
     throw assertionError(shouldNotContain(actual, valuesList, found)); // TODO: ComparisonStrategy???
+  }
+
+  @Override
+  public SELF containsNull() {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      if (actual.contains(null)) {
+        return;
+      }
+
+      throw assertionError(shouldContainNull(actual));
+    });
+  }
+
+  @Override
+  public SELF containsOnlyNulls() {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      if (actual.isEmpty()) {
+        throw assertionError(shouldContainOnlyNulls(actual));
+      }
+
+      RichIterable<? extends ELEMENT> nonNullElements = actual.select(Objects::nonNull);
+      if (nonNullElements.isEmpty()) {
+        return;
+      }
+
+      throw assertionError(shouldContainOnlyNulls(actual, nonNullElements));
+    });
+  }
+
+  @Override
+  public SELF doesNotContainNull() {
+    return executeAssertion(() -> {
+      isNotNull();
+
+      if (!actual.contains(null)) {
+        return;
+      }
+
+      throw assertionError(shouldNotContainNull(actual));
+    });
   }
 
   @Override

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_ContainsNull_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_ContainsNull_Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_ContainsNull_Test {
+  @RichIterableParameterizedTest
+  void passesSingleValue(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements((String) null).containsNull());
+  }
+
+  @RichIterableParameterizedTest
+  void passesWithOtherValues(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", null, "VOY", "ENT").containsNull());
+  }
+
+  @RichIterableParameterizedTest
+  void fails(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").containsNull())
+      .withMessageContaining("to contain a null element");
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().containsNull())
+      .withMessageContaining("to contain a null element");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNull(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().containsNull())
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", null, "VOY", "ENT").containsNull());
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_ContainsOnlyNulls_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_ContainsOnlyNulls_Test.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_ContainsOnlyNulls_Test {
+  @RichIterableParameterizedTest
+  void passesSingleValue(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements((String) null).containsOnlyNulls());
+  }
+
+  @RichIterableParameterizedTest
+  void passesMultipleValues(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements(null, null, null).containsOnlyNulls());
+  }
+
+  @RichIterableParameterizedTest
+  void fails(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").containsOnlyNulls())
+      .withMessageContaining("to contain only null elements but some elements were not");
+  }
+
+  @RichIterableParameterizedTest
+  void failsWithSomeNulls(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements(null, "DS9", null).containsOnlyNulls())
+      .withMessageContaining("to contain only null elements but some elements were not")
+      .withMessageContaining("DS9");
+  }
+
+  @RichIterableParameterizedTest
+  void failsEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromEmpty().containsOnlyNulls())
+      .withMessageContaining("to contain only null elements but it was empty");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNull(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().containsOnlyNulls())
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, null, null).containsOnlyNulls());
+  }
+}

--- a/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_DoesNotContainNull_Test.java
+++ b/src/test/java/org/assertj/eclipse/collections/api/richiterable/AbstractRichIterableAssert_DoesNotContainNull_Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.assertj.eclipse.collections.api.richiterable;
+
+import org.assertj.eclipse.collections.api.SoftAssertions;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class AbstractRichIterableAssert_DoesNotContainNull_Test {
+  @RichIterableParameterizedTest
+  void passes(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromElements("TOS", "TNG", "DS9", "VOY", "ENT").doesNotContainNull());
+  }
+
+  @RichIterableParameterizedTest
+  void passesEmpty(RichIterableAssertFactory<String> assertFactory) {
+    assertThatNoException().isThrownBy(() ->
+      assertFactory.fromEmpty().doesNotContainNull());
+  }
+
+  @RichIterableParameterizedTest
+  void fails(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements((String) null).doesNotContainNull())
+      .withMessageContaining("not to contain null elements");
+  }
+
+  @RichIterableParameterizedTest
+  void failsWithOtherValues(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromElements("TOS", "TNG", null, "VOY", "ENT").doesNotContainNull())
+      .withMessageContaining("not to contain null elements");
+  }
+
+  @RichIterableParameterizedTest
+  void failsNull(RichIterableAssertFactory<String> assertFactory) {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertFactory.fromNull().doesNotContainNull())
+      .withMessageContaining("Expecting actual not to be null");
+  }
+
+  @RichIterableParameterizedTest
+  void softAssertionPasses(RichIterableAssertFactory<String> assertFactory) {
+    SoftAssertions.assertSoftly(softly -> assertFactory.softlyFromElements(softly, "TOS", "TNG", "DS9", "VOY", "ENT").doesNotContainNull());
+  }
+}


### PR DESCRIPTION
Continuing to add methods to AbstractRichIterable. This is for containsNull, doesNotContainNull, and containsOnlyNulls